### PR TITLE
add: jinja2, html

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,56 +2,99 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
-import os
-import re
-import sys
-import logging
-import smtplib
-from email.message import EmailMessage
+import os, re, sys, html, logging, smtplib
 from dataclasses import dataclass
-from typing import List, Optional, Tuple, Dict
+from typing import List, Optional, Dict, Tuple
+from email.message import EmailMessage
 
 import requests
 from bs4 import BeautifulSoup
 from dotenv import load_dotenv
+from jinja2 import Template
 import gspread
 from gspread.exceptions import APIError, SpreadsheetNotFound, WorksheetNotFound
 
-# ------------------------------------------------------------
-# Konfiguracja logowania
-# ------------------------------------------------------------
-LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO").upper()
-logging.basicConfig(
-    level=getattr(logging, LOG_LEVEL, logging.INFO),
-    format="%(asctime)s [%(levelname)s] %(message)s",
-)
+LOG_LEVEL = os.environ.get('LOG_LEVEL', 'INFO').upper()
+logging.basicConfig(level=getattr(logging, LOG_LEVEL, logging.INFO), format='%(asctime)s [%(levelname)s] %(message)s')
 logger = logging.getLogger(__name__)
 
-# ------------------------------------------------------------
-# Stałe & regexy
-# ------------------------------------------------------------
-EPISODE_RE = re.compile(r"Odcinek\s*(\d+)", re.IGNORECASE)
-# Dodatkowo obsłużymy możliwe formaty z myślnikiem, np. "Odcinek 20 - Finał"
-EPISODE_ANY_RE = re.compile(r"Odcinek\s*(\d+)")
+EPISODE_ANY_RE = re.compile(r'Odcinek\s*(\d+)', re.IGNORECASE)
 
-# Nagłówki użytkownika
 DEFAULT_USER_AGENT = (
-    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
-    "(KHTML, like Gecko) Chrome/124.0 Safari/537.36"
+    'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 '
+    '(KHTML, like Gecko) Chrome/124.0 Safari/537.36'
 )
 
-# Domyślne nazwy kolumn (wraz z tolerancją literówki)
-COLUMN_ALIASES = {
-    "nazwa": ["nazwa", "tytuł", "tytul"],
-    "link": ["link", "url"],
-    "obejrzany_odcinek": ["obejrzany_odcinek", "last_watched", "obejrzany"],
-    "odcinek_na_stronie": ["odcinek_na_stronie", "last_on_site", "na_stronie"],
-    "liczba_odcinków": ["liczba_odcinków", "liczba_odicnków", "liczba_odc", "max_odcinek"],
+COLUMN_ALIASES: Dict[str, List[str]] = {
+    'nazwa': ['nazwa', 'tytuł', 'tytul'],
+    'link': ['link', 'url'],
+    'obejrzany_odcinek': ['obejrzany_odcinek', 'last_watched', 'obejrzany'],
+    'odcinek_na_stronie': ['odcinek_na_stronie', 'last_on_site', 'na_stronie'],
+    'liczba_odcinków': ['liczba_odcinków', 'liczba_odicnków', 'liczba_odc', 'max_odcinek'],
 }
+
+HTML_TEMPLATE = Template(r'''<!DOCTYPE html>
+<html lang="pl">
+<head>
+<meta charset="utf-8">
+<title>Powiadomienia o nowych odcinkach K-dram</title>
+<style type="text/css">
+  body{margin:0;padding:0;background:#f7f9fa;font-family:Arial,Helvetica,sans-serif;color:#333}
+  a{color:#ff6699;text-decoration:none}
+  .wrapper{width:100%;table-layout:fixed;background:#f7f9fa;padding:20px 0}
+  .main{width:100%;max-width:600px;background:#fff;margin:0 auto;border-collapse:collapse;border:1px solid #e8ecef}
+  .header{background:#ffeef3;padding:24px;text-align:center}
+  .header h1{margin:0;font-size:24px;color:#cc3066}
+  .episode-block{padding:24px 24px 16px 24px}
+  .episode-title{font-size:18px;margin:0 0 8px 0;color:#222}
+  .episode-update{font-size:14px;margin:0 0 12px 0;line-height:1.5em}
+  .button{display:inline-block;padding:10px 22px;font-size:14px;background:#ff6699;color:#fff !important;border-radius:4px}
+  .divider{height:1px;background:#f2f4f6;border:none;margin:0 24px}
+  .footer{padding:16px 24px;font-size:12px;color:#999;text-align:center}
+  @media only screen and (max-width:620px){.episode-block{padding:16px !important}.header h1{font-size:20px !important}}
+</style>
+</head>
+<body>
+<center class="wrapper">
+<table class="main" role="presentation" cellpadding="0" cellspacing="0">
+<tr><td class="header"><h1>Twoje nowe odcinki K-dram</h1></td></tr>
+
+{% if new_items and new_items|length > 0 %}
+  {% for d in new_items %}
+    <tr><td class="episode-block">
+      <h2 class="episode-title">{{ d.get('tytuł') or d.get('nazwa') }}</h2>
+      <p class="episode-update">
+        <strong>Update</strong>: obejrzano odcinek <strong>{{ d.get('ostatni_obejrzany') }}</strong>
+        {% if d.get('liczba_odcinków') %} z <strong>{{ d.get('liczba_odcinków') }}</strong>{% endif %},
+        nowy odcinek: <strong>{{ d.get('nowy_odcinek') }}</strong>.
+      </p>
+      {% if d.get('link') %}
+        <a href="{{ d.get('link') }}" class="button" target="_blank">Zobacz nowy odcinek</a>
+      {% endif %}
+    </td></tr>
+    {% if not loop.last %}<tr><td><hr class="divider"></td></tr>{% endif %}
+  {% endfor %}
+{% else %}
+  <tr><td class="episode-block"><h2 class="episode-title">Brak nowych odcinków do obejrzenia.</h2></td></tr>
+{% endif %}
+
+<tr><td><hr class="divider"></td></tr>
+<tr><td class="episode-block"><h2 class="episode-title">Problemy techniczne</h2>
+  {% if problems and problems|length > 0 %}
+    <ul style="padding-left:18px;margin:8px 0">
+      {% for p in problems %}<li style="margin-bottom:6px">{{ p }}</li>{% endfor %}
+    </ul>
+  {% else %}<p class="episode-update">brak</p>{% endif %}
+</td></tr>
+<tr><td class="footer">Życzymy miłego seansu!</td></tr>
+</table>
+</center>
+</body>
+</html>''' )
 
 @dataclass
 class SeriesRow:
-    row_idx: int  # 1-based index w arkuszu (włącznie z nagłówkiem)
+    row_idx: int
     nazwa: str
     link: str
     obejrzany_odcinek: int
@@ -60,26 +103,20 @@ class SeriesRow:
 
     @property
     def is_done(self) -> bool:
-        return (
-            self.obejrzany_odcinek == self.odcinek_na_stronie == self.liczba_odcinków
-        )
+        return self.obejrzany_odcinek == self.odcinek_na_stronie == self.liczba_odcinków
+
 
 @dataclass
 class EpisodeCheckResult:
-    latest_ready: Optional[int]  # najnowszy gotowy (bez <img> w nagłówku)
-    max_found: Optional[int]     # najwyższy numer odcinka znaleziony na stronie (niezależnie od <img>)
+    latest_ready: Optional[int]
+    max_found: Optional[int]
     error: Optional[str] = None
-
-# ------------------------------------------------------------
-# Utilsy
-# ------------------------------------------------------------
 
 def getenv_int(name: str, default: int) -> int:
     try:
         return int(os.environ.get(name, str(default)))
     except Exception:
         return default
-
 
 def parse_int(value: object, default: int = 0) -> int:
     try:
@@ -90,261 +127,181 @@ def parse_int(value: object, default: int = 0) -> int:
         s = str(value).strip()
         if not s:
             return default
-        return int(re.sub(r"\D", "", s))
+        return int(re.sub(r'\D', '', s))
     except Exception:
         return default
 
-
-# ------------------------------------------------------------
-# Parsowanie HTML – logika odcinków
-# ------------------------------------------------------------
+def build_email_html(new_items: List[dict], problems: List[str]) -> str:
+    new_items = new_items or []
+    problems = problems or []
+    try:
+        return HTML_TEMPLATE.render(new_items=new_items, problems=problems)
+    except Exception as e:
+        logger.exception('Błąd renderowania HTML: %s', e)
+        esc = html.escape(str(e))
+        return f'<pre>Błąd generowania HTML: {esc}\nNowe: {len(new_items)}, Problemy: {len(problems)}</pre>'
 
 def extract_episode_number(text: str) -> Optional[int]:
-    match = EPISODE_ANY_RE.search(text)
-    if match:
+    m = EPISODE_ANY_RE.search(text)
+    if m:
         try:
-            return int(match.group(1))
+            return int(m.group(1))
         except Exception:
             return None
     return None
 
-
-def find_episodes(html: str) -> EpisodeCheckResult:
-    """Zwraca najnowszy gotowy odcinek (bez <img> w p.toggler) i max numer odcinka.
-    W razie problemu ustawia error.
-    """
+def find_episodes(html_text: str) -> EpisodeCheckResult:
     try:
-        soup = BeautifulSoup(html, "html.parser")
-        p_tags = soup.find_all("p", class_=lambda c: c and "toggler" in c)
+        soup = BeautifulSoup(html_text, 'html.parser')
+        p_tags = soup.find_all('p', class_=lambda c: c and 'toggler' in c)
         latest_ready = None
         max_found = None
-
         for p in p_tags:
-            text = p.get_text(" ", strip=True)
-            num = extract_episode_number(text)
+            num = extract_episode_number(p.get_text(' ', strip=True))
             if num is not None:
                 if max_found is None or num > max_found:
                     max_found = num
-            # jeżeli w nagłówku jest <img> – to jest korekta/tłumaczenie => NIE gotowy
-            has_img = p.find("img") is not None
+            has_img = p.find('img') is not None
             if not has_img and num is not None:
                 if latest_ready is None or num > latest_ready:
                     latest_ready = num
-
         if latest_ready is None and max_found is None:
-            return EpisodeCheckResult(None, None, error="Nie znaleziono żadnego nagłówka odcinka.")
+            return EpisodeCheckResult(None, None, error='Nie znaleziono nagłówków odcinków.')
         return EpisodeCheckResult(latest_ready, max_found, None)
     except Exception as e:
-        return EpisodeCheckResult(None, None, error=f"Błąd parsowania HTML: {e}")
-
-
-# ------------------------------------------------------------
-# Dostęp do Google Sheets
-# ------------------------------------------------------------
+        return EpisodeCheckResult(None, None, error=f'Błąd parsowania HTML: {e}')
 
 def authenticate_gspread(service_account_file: str) -> gspread.Client:
-    # Zalecana autoryzacja przez konto serwisowe
     return gspread.service_account(filename=service_account_file)
 
-
 def open_sheet(gc: gspread.Client, spreadsheet_title: str, worksheet_title: str):
-    # Otwieramy arkusz przez tytuł – alternatywnie można użyć ID (bezpieczniej)
     try:
         sh = gc.open(spreadsheet_title)
     except SpreadsheetNotFound as e:
-        raise RuntimeError(
-            "Nie znaleziono arkusza. Upewnij się, że udostępniłeś arkusz na adres 'client_email' z pliku service_account.json."
-        ) from e
-
+        raise RuntimeError('Nie znaleziono arkusza.') from e
     try:
         ws = sh.worksheet(worksheet_title)
-    except WorksheetNotFound as e:
-        # Fallback: weź pierwszy
+    except WorksheetNotFound:
         ws = sh.sheet1
-        logger.warning(
-            "Nie znaleziono zakładki '%s'. Używam pierwszej zakładki: %s",
-            worksheet_title, ws.title,
-        )
+        logger.warning('Nie znaleziono zakładki %s – używam pierwszej.', worksheet_title)
     return sh, ws
 
-
 def map_headers(header_row: List[str]) -> Dict[str, int]:
-    """Zwraca mapowanie 'kanoniczna_nazwa' -> index kolumny (0-based)."""
-    header_norm = [str(h or "").strip().lower() for h in header_row]
+    normalized = [str(h or '').strip().lower() for h in header_row]
     mapping: Dict[str, int] = {}
     for canon, aliases in COLUMN_ALIASES.items():
-        for alias in aliases:
-            if alias in header_norm:
-                mapping[canon] = header_norm.index(alias)
+        for a in aliases:
+            if a in normalized:
+                mapping[canon] = normalized.index(a)
                 break
-    missing = [k for k in ("nazwa", "link", "obejrzany_odcinek", "odcinek_na_stronie", "liczba_odcinków") if k not in mapping]
+    missing = [k for k in ('nazwa','link','obejrzany_odcinek','odcinek_na_stronie','liczba_odcinków') if k not in mapping]
     if missing:
-        raise RuntimeError(f"Brak wymaganych kolumn w nagłówku: {missing}. Otrzymano: {header_row}")
+        raise RuntimeError(f'Brak wymaganych kolumn: {missing}')
     return mapping
 
-
 def read_series(ws) -> Tuple[List[SeriesRow], List[str], Dict[str, int]]:
-    """Wczytuje wszystkie wiersze i mapuje na SeriesRow."""
-    values = ws.get_all_values()  # 2D list
+    values = ws.get_all_values()
     if not values:
-        raise RuntimeError("Arkusz jest pusty.")
+        raise RuntimeError('Arkusz jest pusty.')
     header = values[0]
     mapping = map_headers(header)
-
     rows: List[SeriesRow] = []
-    for i, row in enumerate(values[1:], start=2):  # 1=header, więc dane od 2
+    for i, row in enumerate(values[1:], start=2):
         def get(idx: int) -> str:
-            return row[idx] if idx < len(row) else ""
-
-        s = SeriesRow(
+            return row[idx] if idx < len(row) else ''
+        rows.append(SeriesRow(
             row_idx=i,
-            nazwa=get(mapping["nazwa"]),
-            link=get(mapping["link"]),
-            obejrzany_odcinek=parse_int(get(mapping["obejrzany_odcinek"]), 0),
-            odcinek_na_stronie=parse_int(get(mapping["odcinek_na_stronie"]), 0),
-            liczba_odcinków=parse_int(get(mapping["liczba_odcinków"]), 0),
-        )
-        rows.append(s)
+            nazwa=get(mapping['nazwa']),
+            link=get(mapping['link']),
+            obejrzany_odcinek=parse_int(get(mapping['obejrzany_odcinek']), 0),
+            odcinek_na_stronie=parse_int(get(mapping['odcinek_na_stronie']), 0),
+            liczba_odcinków=parse_int(get(mapping['liczba_odcinków']), 0),
+        ))
     return rows, header, mapping
 
-
 def update_cell(ws, row_idx: int, col_idx: int, value: object):
-    # gspread jest 1-based
     ws.update_cell(row_idx, col_idx, value)
-
-
-# ------------------------------------------------------------
-# Email
-# ------------------------------------------------------------
-
-def build_email_body(new_items: List[dict], problems: List[str]) -> str:
-    lines: List[str] = []
-    if new_items:
-        lines.append("Nowe odcinki do obejrzenia:\n")
-        for i, it in enumerate(new_items, start=1):
-            lines.append(f"{i}. Tytuł: {it['tytuł']}")
-            lines.append(f"   Nowy odcinek: {it['nowy_odcinek']}")
-            lines.append(f"   Ostatni obejrzany: {it['ostatni_obejrzany']}")
-            lines.append(f"   Link: {it['link']}\n")
-    else:
-        lines.append("Brak nowych odcinków do obejrzenia.\n")
-
-    if problems:
-        lines.append("Problemy techniczne:")
-        for p in problems:
-            lines.append(f"- {p}")
-    else:
-        lines.append("Problemy techniczne: brak")
-
-    return "\n".join(lines)
-
-
-def send_email(subject: str, body: str) -> None:
-    smtp_host = os.environ.get("SMTP_HOST", "smtp.gmail.com")
-    smtp_port = getenv_int("SMTP_PORT", 587)
-    smtp_user = os.environ.get("SMTP_USER")
-    smtp_pass = os.environ.get("SMTP_PASS")
-    email_to = os.environ.get("EMAIL_TO")
-    email_from = os.environ.get("EMAIL_FROM", smtp_user)
-
-    if not (smtp_user and smtp_pass and email_to):
-        raise RuntimeError("Brak ustawień SMTP/EMAIL_TO w .env")
-
-    msg = EmailMessage()
-    msg["From"] = email_from
-    msg["To"] = email_to
-    msg["Subject"] = subject
-    msg.set_content(body)
-
-    with smtplib.SMTP(smtp_host, smtp_port, timeout=60) as server:
-        server.ehlo()
-        # STARTTLS jeśli port 587
-        if smtp_port == 587:
-            server.starttls()
-            server.ehlo()
-        server.login(smtp_user, smtp_pass)
-        server.send_message(msg)
-        logger.info("Wysłano e-mail do %s", email_to)
-
-
-# ------------------------------------------------------------
-# Główna logika
-# ------------------------------------------------------------
 
 def build_requests_session() -> requests.Session:
     s = requests.Session()
-    s.headers.update({"User-Agent": DEFAULT_USER_AGENT})
-
-    # Ciasteczka WordPress / DramaQueen – nazwy mogą się różnić; pobierz z .env
-    php_sessid = os.environ.get("PHPSESSID")
+    s.headers.update({'User-Agent': DEFAULT_USER_AGENT})
+    php_sessid = os.environ.get('PHPSESSID')
     if php_sessid:
-        s.cookies.set("PHPSESSID", php_sessid, domain="www.dramaqueen.pl")
-
-    # Dwa inne ciastka mogą mieć zmienny suffix; przekaż nazwę i wartość
-    wp_logged_in_name = os.environ.get("WP_LOGGED_IN_COOKIE_NAME")
-    wp_logged_in_val = os.environ.get("WP_LOGGED_IN_COOKIE_VALUE")
-    if wp_logged_in_name and wp_logged_in_val:
-        s.cookies.set(wp_logged_in_name, wp_logged_in_val, domain="www.dramaqueen.pl")
-
-    wp_sec_name = os.environ.get("WP_SEC_COOKIE_NAME")
-    wp_sec_val = os.environ.get("WP_SEC_COOKIE_VALUE")
+        s.cookies.set('PHPSESSID', php_sessid, domain='www.dramaqueen.pl')
+    wp_logged_name = os.environ.get('WP_LOGGED_IN_COOKIE_NAME')
+    wp_logged_val = os.environ.get('WP_LOGGED_IN_COOKIE_VALUE')
+    if wp_logged_name and wp_logged_val:
+        s.cookies.set(wp_logged_name, wp_logged_val, domain='www.dramaqueen.pl')
+    wp_sec_name = os.environ.get('WP_SEC_COOKIE_NAME')
+    wp_sec_val = os.environ.get('WP_SEC_COOKIE_VALUE')
     if wp_sec_name and wp_sec_val:
-        s.cookies.set(wp_sec_name, wp_sec_val, domain="www.dramaqueen.pl")
-
+        s.cookies.set(wp_sec_name, wp_sec_val, domain='www.dramaqueen.pl')
     return s
-
 
 def check_series(session: requests.Session, series: SeriesRow) -> EpisodeCheckResult:
     try:
         resp = session.get(series.link, timeout=60)
         if resp.status_code != 200:
-            return EpisodeCheckResult(None, None, error=f"{series.nazwa}: HTTP {resp.status_code}")
+            return EpisodeCheckResult(None, None, error=f'{series.nazwa}: HTTP {resp.status_code}')
         return find_episodes(resp.text)
     except Exception as e:
-        return EpisodeCheckResult(None, None, error=f"{series.nazwa}: błąd pobierania: {e}")
+        return EpisodeCheckResult(None, None, error=f'{series.nazwa}: błąd pobierania: {e}')
 
+def send_email(subject: str, html_body: str) -> None:
+    smtp_host = os.environ.get('SMTP_HOST', 'smtp.gmail.com')
+    smtp_port = int(os.environ.get('SMTP_PORT', '587'))
+    smtp_user = os.environ.get('SMTP_USER')
+    smtp_pass = os.environ.get('SMTP_PASS')
+    email_to  = os.environ.get('EMAIL_TO')
+    email_from = os.environ.get('EMAIL_FROM', smtp_user)
+    if not (smtp_user and smtp_pass and email_to):
+        raise RuntimeError('Brak ustawień SMTP/EMAIL_TO')
+
+    msg = EmailMessage()
+    msg['From'] = email_from
+    msg['To'] = email_to
+    msg['Subject'] = subject
+    msg.add_alternative(html_body, subtype='html')
+
+    with smtplib.SMTP(smtp_host, smtp_port, timeout=60) as server:
+        server.ehlo()
+        if smtp_port == 587:
+            server.starttls(); server.ehlo()
+        server.login(smtp_user, smtp_pass)
+        server.send_message(msg)
+        logger.info('Wysłano e-mail HTML do %s', email_to)
 
 def main() -> int:
     load_dotenv()
+    spreadsheet_title = os.environ.get('SHEET_TITLE', 'dramy')
+    worksheet_title   = os.environ.get('WORKSHEET_TITLE', 'arkusz1')
+    service_account_file = os.environ.get('GSPREAD_SERVICE_ACCOUNT_FILE', 'service_account.json')
+    always_send = os.environ.get('ALWAYS_SEND', '1') in ('1','true','True','yes','tak')
 
-    spreadsheet_title = os.environ.get("SHEET_TITLE", "dramy")
-    worksheet_title = os.environ.get("WORKSHEET_TITLE", "arkusz1")
-    service_account_file = os.environ.get("GSPREAD_SERVICE_ACCOUNT_FILE", "service_account.json")
-
-    always_send = os.environ.get("ALWAYS_SEND", "1") in ("1", "true", "True", "yes", "tak")
-
-    # 1. GSheets – wczytaj dane
+    # 1. Sheets
     try:
         gc = authenticate_gspread(service_account_file)
         sh, ws = open_sheet(gc, spreadsheet_title, worksheet_title)
         rows, header, mapping = read_series(ws)
-        logger.info("Wczytano %d wierszy z arkusza '%s/%s'", len(rows), spreadsheet_title, ws.title)
+        logger.info('Wczytano %d wierszy', len(rows))
     except Exception as e:
-        logger.exception("Błąd dostępu do Google Sheets: %s", e)
-        # Jeśli nawet Sheets padnie – wyślij e-mail z informacją o błędzie
+        logger.exception('Błąd dostępu do Google Sheets: %s', e)
         try:
-            send_email("Sprawdzacz odcinków – błąd Sheets", f"Błąd dostępu do Google Sheets: {e}")
+            send_email('Sprawdzacz odcinków – błąd Sheets', f'<pre>Błąd: {html.escape(str(e))}</pre>')
         except Exception:
             pass
         return 2
 
-    # 2. HTTP session z ciasteczkami
     session = build_requests_session()
-
     new_items: List[dict] = []
     problems: List[str] = []
 
-    # 3. Iteracja po wierszach
     for s in rows:
-        # Pomiń kompletne (obejrzany == na_stronie == liczba)
         if s.is_done:
-            logger.debug("Pomijam kompletne: %s", s.nazwa)
             continue
-
         if not s.link:
-            problems.append(f"{s.nazwa}: brak linku w arkuszu")
+            problems.append(f'{s.nazwa}: brak linku w arkuszu')
             continue
-
         result = check_series(session, s)
         if result.error:
             problems.append(result.error)
@@ -353,49 +310,44 @@ def main() -> int:
         latest_ready = result.latest_ready or 0
         max_found = result.max_found or 0
 
-        # 3a. Aktualizacja 'odcinek_na_stronie' jeśli większy
         try:
             if latest_ready > s.odcinek_na_stronie:
-                logger.info("%s: aktualizacja odcinek_na_stronie %d -> %d", s.nazwa, s.odcinek_na_stronie, latest_ready)
-                update_cell(ws, s.row_idx, mapping["odcinek_na_stronie"] + 1, latest_ready)
+                update_cell(ws, s.row_idx, mapping['odcinek_na_stronie'] + 1, latest_ready)
                 s.odcinek_na_stronie = latest_ready
         except APIError as e:
-            problems.append(f"{s.nazwa}: błąd aktualizacji arkusza: {e}")
+            problems.append(f'{s.nazwa}: błąd aktualizacji arkusza: {e}')
 
-        # (opcjonalnie) aktualizuj liczba_odcinków jeżeli wykryto większy max
         try:
             if max_found > s.liczba_odcinków:
-                logger.info("%s: aktualizacja liczba_odcinków %d -> %d", s.nazwa, s.liczba_odcinków, max_found)
-                update_cell(ws, s.row_idx, mapping["liczba_odcinków"] + 1, max_found)
+                update_cell(ws, s.row_idx, mapping['liczba_odcinków'] + 1, max_found)
                 s.liczba_odcinków = max_found
         except APIError as e:
-            problems.append(f"{s.nazwa}: błąd aktualizacji liczby odcinków: {e}")
+            problems.append(f'{s.nazwa}: błąd aktualizacji liczby odcinków: {e}')
 
-        # 3b. Jeżeli obejrzany < na_stronie – dodaj do listy powiadomień
         if s.obejrzany_odcinek < s.odcinek_na_stronie:
             new_items.append({
-                "tytuł": s.nazwa,
-                "nowy_odcinek": s.odcinek_na_stronie,
-                "ostatni_obejrzany": s.obejrzany_odcinek,
-                "link": s.link,
+                'tytuł': s.nazwa,
+                'nowy_odcinek': s.odcinek_na_stronie,
+                'ostatni_obejrzany': s.obejrzany_odcinek,
+                'liczba_odcinków': s.liczba_odcinków,
+                'link': s.link,
             })
 
-    # 4. E-mail
-    subject = "Nowe odcinki do obejrzenia – Sprawdzacz"
-    body = build_email_body(new_items, problems)
+    subject = 'Nowe odcinki do obejrzenia – Sprawdzacz'
+    html_body = build_email_html(new_items, problems)
 
     if always_send or new_items or problems:
         try:
-            send_email(subject, body)
+            send_email(subject, html_body)
         except Exception as e:
-            logger.exception("Błąd wysyłki e-mail: %s", e)
+            logger.exception('Błąd wysyłki e-mail: %s', e)
             return 3
     else:
-        logger.info("Brak zmian – nie wysyłam e-maila.")
+        logger.info('Brak zmian – e-mail nie został wysłany.')
 
-    logger.info("Zakończono.")
+    logger.info('Zakończono.')
     return 0
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     sys.exit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "google-auth>=2.40.3",
     "google-auth-oauthlib>=1.2.2",
     "gspread>=6.2.1",
+    "jinja2>=3.1.6",
     "python-dotenv>=1.1.1",
     "requests>=2.32.4",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -90,6 +90,7 @@ dependencies = [
     { name = "google-auth" },
     { name = "google-auth-oauthlib" },
     { name = "gspread" },
+    { name = "jinja2" },
     { name = "python-dotenv" },
     { name = "requests" },
 ]
@@ -100,6 +101,7 @@ requires-dist = [
     { name = "google-auth", specifier = ">=2.40.3" },
     { name = "google-auth-oauthlib", specifier = ">=1.2.2" },
     { name = "gspread", specifier = ">=6.2.1" },
+    { name = "jinja2", specifier = ">=3.1.6" },
     { name = "python-dotenv", specifier = ">=1.1.1" },
     { name = "requests", specifier = ">=2.32.4" },
 ]
@@ -151,6 +153,66 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/97/5d42485e71dfc078108a86d6de8fa46db44a1a9295e89c5d6d4a06e23a62/markupsafe-3.0.2.tar.gz", hash = "sha256:ee55d3edf80167e48ea11a923c7386f4669df67d7994554387f84e7d8b0a2bf0", size = 20537, upload-time = "2024-10-18T15:21:54.129Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6b/28/bbf83e3f76936960b850435576dd5e67034e200469571be53f69174a2dfd/MarkupSafe-3.0.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:9025b4018f3a1314059769c7bf15441064b2207cb3f065e6ea1e7359cb46db9d", size = 14353, upload-time = "2024-10-18T15:21:02.187Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/30/316d194b093cde57d448a4c3209f22e3046c5bb2fb0820b118292b334be7/MarkupSafe-3.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:93335ca3812df2f366e80509ae119189886b0f3c2b81325d39efdb84a1e2ae93", size = 12392, upload-time = "2024-10-18T15:21:02.941Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/96/9cdafba8445d3a53cae530aaf83c38ec64c4d5427d975c974084af5bc5d2/MarkupSafe-3.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2cb8438c3cbb25e220c2ab33bb226559e7afb3baec11c4f218ffa7308603c832", size = 23984, upload-time = "2024-10-18T15:21:03.953Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/a4/aefb044a2cd8d7334c8a47d3fb2c9f328ac48cb349468cc31c20b539305f/MarkupSafe-3.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a123e330ef0853c6e822384873bef7507557d8e4a082961e1defa947aa59ba84", size = 23120, upload-time = "2024-10-18T15:21:06.495Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/21/5e4851379f88f3fad1de30361db501300d4f07bcad047d3cb0449fc51f8c/MarkupSafe-3.0.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1e084f686b92e5b83186b07e8a17fc09e38fff551f3602b249881fec658d3eca", size = 23032, upload-time = "2024-10-18T15:21:07.295Z" },
+    { url = "https://files.pythonhosted.org/packages/00/7b/e92c64e079b2d0d7ddf69899c98842f3f9a60a1ae72657c89ce2655c999d/MarkupSafe-3.0.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d8213e09c917a951de9d09ecee036d5c7d36cb6cb7dbaece4c71a60d79fb9798", size = 24057, upload-time = "2024-10-18T15:21:08.073Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/ac/46f960ca323037caa0a10662ef97d0a4728e890334fc156b9f9e52bcc4ca/MarkupSafe-3.0.2-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:5b02fb34468b6aaa40dfc198d813a641e3a63b98c2b05a16b9f80b7ec314185e", size = 23359, upload-time = "2024-10-18T15:21:09.318Z" },
+    { url = "https://files.pythonhosted.org/packages/69/84/83439e16197337b8b14b6a5b9c2105fff81d42c2a7c5b58ac7b62ee2c3b1/MarkupSafe-3.0.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0bff5e0ae4ef2e1ae4fdf2dfd5b76c75e5c2fa4132d05fc1b0dabcd20c7e28c4", size = 23306, upload-time = "2024-10-18T15:21:10.185Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/34/a15aa69f01e2181ed8d2b685c0d2f6655d5cca2c4db0ddea775e631918cd/MarkupSafe-3.0.2-cp311-cp311-win32.whl", hash = "sha256:6c89876f41da747c8d3677a2b540fb32ef5715f97b66eeb0c6b66f5e3ef6f59d", size = 15094, upload-time = "2024-10-18T15:21:11.005Z" },
+    { url = "https://files.pythonhosted.org/packages/da/b8/3a3bd761922d416f3dc5d00bfbed11f66b1ab89a0c2b6e887240a30b0f6b/MarkupSafe-3.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:70a87b411535ccad5ef2f1df5136506a10775d267e197e4cf531ced10537bd6b", size = 15521, upload-time = "2024-10-18T15:21:12.911Z" },
+    { url = "https://files.pythonhosted.org/packages/22/09/d1f21434c97fc42f09d290cbb6350d44eb12f09cc62c9476effdb33a18aa/MarkupSafe-3.0.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:9778bd8ab0a994ebf6f84c2b949e65736d5575320a17ae8984a77fab08db94cf", size = 14274, upload-time = "2024-10-18T15:21:13.777Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/b0/18f76bba336fa5aecf79d45dcd6c806c280ec44538b3c13671d49099fdd0/MarkupSafe-3.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:846ade7b71e3536c4e56b386c2a47adf5741d2d8b94ec9dc3e92e5e1ee1e2225", size = 12348, upload-time = "2024-10-18T15:21:14.822Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/25/dd5c0f6ac1311e9b40f4af06c78efde0f3b5cbf02502f8ef9501294c425b/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1c99d261bd2d5f6b59325c92c73df481e05e57f19837bdca8413b9eac4bd8028", size = 24149, upload-time = "2024-10-18T15:21:15.642Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/f0/89e7aadfb3749d0f52234a0c8c7867877876e0a20b60e2188e9850794c17/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e17c96c14e19278594aa4841ec148115f9c7615a47382ecb6b82bd8fea3ab0c8", size = 23118, upload-time = "2024-10-18T15:21:17.133Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/da/f2eeb64c723f5e3777bc081da884b414671982008c47dcc1873d81f625b6/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:88416bd1e65dcea10bc7569faacb2c20ce071dd1f87539ca2ab364bf6231393c", size = 22993, upload-time = "2024-10-18T15:21:18.064Z" },
+    { url = "https://files.pythonhosted.org/packages/da/0e/1f32af846df486dce7c227fe0f2398dc7e2e51d4a370508281f3c1c5cddc/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2181e67807fc2fa785d0592dc2d6206c019b9502410671cc905d132a92866557", size = 24178, upload-time = "2024-10-18T15:21:18.859Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f6/bb3ca0532de8086cbff5f06d137064c8410d10779c4c127e0e47d17c0b71/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:52305740fe773d09cffb16f8ed0427942901f00adedac82ec8b67752f58a1b22", size = 23319, upload-time = "2024-10-18T15:21:19.671Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/82/8be4c96ffee03c5b4a034e60a31294daf481e12c7c43ab8e34a1453ee48b/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ad10d3ded218f1039f11a75f8091880239651b52e9bb592ca27de44eed242a48", size = 23352, upload-time = "2024-10-18T15:21:20.971Z" },
+    { url = "https://files.pythonhosted.org/packages/51/ae/97827349d3fcffee7e184bdf7f41cd6b88d9919c80f0263ba7acd1bbcb18/MarkupSafe-3.0.2-cp312-cp312-win32.whl", hash = "sha256:0f4ca02bea9a23221c0182836703cbf8930c5e9454bacce27e767509fa286a30", size = 15097, upload-time = "2024-10-18T15:21:22.646Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/80/a61f99dc3a936413c3ee4e1eecac96c0da5ed07ad56fd975f1a9da5bc630/MarkupSafe-3.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:8e06879fc22a25ca47312fbe7c8264eb0b662f6db27cb2d3bbbc74b1df4b9b87", size = 15601, upload-time = "2024-10-18T15:21:23.499Z" },
+    { url = "https://files.pythonhosted.org/packages/83/0e/67eb10a7ecc77a0c2bbe2b0235765b98d164d81600746914bebada795e97/MarkupSafe-3.0.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ba9527cdd4c926ed0760bc301f6728ef34d841f405abf9d4f959c478421e4efd", size = 14274, upload-time = "2024-10-18T15:21:24.577Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/6d/9409f3684d3335375d04e5f05744dfe7e9f120062c9857df4ab490a1031a/MarkupSafe-3.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f8b3d067f2e40fe93e1ccdd6b2e1d16c43140e76f02fb1319a05cf2b79d99430", size = 12352, upload-time = "2024-10-18T15:21:25.382Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/f5/6eadfcd3885ea85fe2a7c128315cc1bb7241e1987443d78c8fe712d03091/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:569511d3b58c8791ab4c2e1285575265991e6d8f8700c7be0e88f86cb0672094", size = 24122, upload-time = "2024-10-18T15:21:26.199Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/91/96cf928db8236f1bfab6ce15ad070dfdd02ed88261c2afafd4b43575e9e9/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:15ab75ef81add55874e7ab7055e9c397312385bd9ced94920f2802310c930396", size = 23085, upload-time = "2024-10-18T15:21:27.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/cf/c9d56af24d56ea04daae7ac0940232d31d5a8354f2b457c6d856b2057d69/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f3818cb119498c0678015754eba762e0d61e5b52d34c8b13d770f0719f7b1d79", size = 22978, upload-time = "2024-10-18T15:21:27.846Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/9f/8619835cd6a711d6272d62abb78c033bda638fdc54c4e7f4272cf1c0962b/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cdb82a876c47801bb54a690c5ae105a46b392ac6099881cdfb9f6e95e4014c6a", size = 24208, upload-time = "2024-10-18T15:21:28.744Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/bf/176950a1792b2cd2102b8ffeb5133e1ed984547b75db47c25a67d3359f77/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:cabc348d87e913db6ab4aa100f01b08f481097838bdddf7c7a84b7575b7309ca", size = 23357, upload-time = "2024-10-18T15:21:29.545Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/4f/9a02c1d335caabe5c4efb90e1b6e8ee944aa245c1aaaab8e8a618987d816/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:444dcda765c8a838eaae23112db52f1efaf750daddb2d9ca300bcae1039adc5c", size = 23344, upload-time = "2024-10-18T15:21:30.366Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/55/c271b57db36f748f0e04a759ace9f8f759ccf22b4960c270c78a394f58be/MarkupSafe-3.0.2-cp313-cp313-win32.whl", hash = "sha256:bcf3e58998965654fdaff38e58584d8937aa3096ab5354d493c77d1fdd66d7a1", size = 15101, upload-time = "2024-10-18T15:21:31.207Z" },
+    { url = "https://files.pythonhosted.org/packages/29/88/07df22d2dd4df40aba9f3e402e6dc1b8ee86297dddbad4872bd5e7b0094f/MarkupSafe-3.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:e6a2a455bd412959b57a172ce6328d2dd1f01cb2135efda2e4576e8a23fa3b0f", size = 15603, upload-time = "2024-10-18T15:21:32.032Z" },
+    { url = "https://files.pythonhosted.org/packages/62/6a/8b89d24db2d32d433dffcd6a8779159da109842434f1dd2f6e71f32f738c/MarkupSafe-3.0.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:b5a6b3ada725cea8a5e634536b1b01c30bcdcd7f9c6fff4151548d5bf6b3a36c", size = 14510, upload-time = "2024-10-18T15:21:33.625Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/06/a10f955f70a2e5a9bf78d11a161029d278eeacbd35ef806c3fd17b13060d/MarkupSafe-3.0.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a904af0a6162c73e3edcb969eeeb53a63ceeb5d8cf642fade7d39e7963a22ddb", size = 12486, upload-time = "2024-10-18T15:21:34.611Z" },
+    { url = "https://files.pythonhosted.org/packages/34/cf/65d4a571869a1a9078198ca28f39fba5fbb910f952f9dbc5220afff9f5e6/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4aa4e5faecf353ed117801a068ebab7b7e09ffb6e1d5e412dc852e0da018126c", size = 25480, upload-time = "2024-10-18T15:21:35.398Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/e3/90e9651924c430b885468b56b3d597cabf6d72be4b24a0acd1fa0e12af67/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c0ef13eaeee5b615fb07c9a7dadb38eac06a0608b41570d8ade51c56539e509d", size = 23914, upload-time = "2024-10-18T15:21:36.231Z" },
+    { url = "https://files.pythonhosted.org/packages/66/8c/6c7cf61f95d63bb866db39085150df1f2a5bd3335298f14a66b48e92659c/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d16a81a06776313e817c951135cf7340a3e91e8c1ff2fac444cfd75fffa04afe", size = 23796, upload-time = "2024-10-18T15:21:37.073Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/35/cbe9238ec3f47ac9a7c8b3df7a808e7cb50fe149dc7039f5f454b3fba218/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:6381026f158fdb7c72a168278597a5e3a5222e83ea18f543112b2662a9b699c5", size = 25473, upload-time = "2024-10-18T15:21:37.932Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/32/7621a4382488aa283cc05e8984a9c219abad3bca087be9ec77e89939ded9/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:3d79d162e7be8f996986c064d1c7c817f6df3a77fe3d6859f6f9e7be4b8c213a", size = 24114, upload-time = "2024-10-18T15:21:39.799Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/80/0985960e4b89922cb5a0bac0ed39c5b96cbc1a536a99f30e8c220a996ed9/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:131a3c7689c85f5ad20f9f6fb1b866f402c445b220c19fe4308c0b147ccd2ad9", size = 24098, upload-time = "2024-10-18T15:21:40.813Z" },
+    { url = "https://files.pythonhosted.org/packages/82/78/fedb03c7d5380df2427038ec8d973587e90561b2d90cd472ce9254cf348b/MarkupSafe-3.0.2-cp313-cp313t-win32.whl", hash = "sha256:ba8062ed2cf21c07a9e295d5b8a2a5ce678b913b45fdf68c32d95d6c1291e0b6", size = 15208, upload-time = "2024-10-18T15:21:41.814Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/65/6079a46068dfceaeabb5dcad6d674f5f5c61a6fa5673746f42a9f4c233b3/MarkupSafe-3.0.2-cp313-cp313t-win_amd64.whl", hash = "sha256:e444a31f8db13eb18ada366ab3cf45fd4b31e4db1236a4448f68778c1d1a5a2f", size = 15739, upload-time = "2024-10-18T15:21:42.784Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
DramaChecker – sprawdzanie nowych odcinków i wysyłka HTML (v0.2.0, 2025-07-30)

Zmiany:
* Dodano renderowanie e‑maila w HTML (Jinja2) – build_email_html().
* Funkcja send_email wysyła tylko część text/html.
* W main() zastąpiono build_email_body wywołaniem build_email_html.
* Wymagana nowa zależność: jinja2>=3.1.6 (dodaj w "pyproject.toml").