### PR TITLE
Milestone 1.2: retry odzyskania sesji dla błędów logowania

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Skrypt sprawdzający nowe odcinki K-dram w arkuszu Google Sheets i wysyłający 
 
 Obsługuje automatyczne logowanie do DramaQueen przez Playwright, więc nie trzeba już ręcznie odnawiać cookie w `.env`.
 Po zalogowaniu przenosi do `requests.Session` pełny zestaw cookie z przeglądarki, co jest potrzebne dla części stron takich jak `City Hunter`.
+Dla chwilowych problemów logowania działa retry odzyskania sesji (2 próby), żeby ograniczyć losowe błędy pojedynczych seriali.
 
 ## Uruchamianie
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -83,3 +83,28 @@ Uwagi:
 - milestone zależny od realizacji Milestone 1.0
 - README uzupełnione o konfigurację i uruchamianie Playwright
 - istnieją testy jednostkowe oraz smoke test `process_user()` bez realnego IO
+
+---
+
+## Milestone 1.2: Retry odzyskania sesji dla chwilowych błędów logowania (done)
+
+Cel:
+- ograniczyć losowe błędy typu `Po logowaniu nie znaleziono wymaganych cookie sesyjnych`
+- zapewnić ponowienie sprawdzenia serialu po chwilowej awarii odzyskania sesji
+
+Definition of Done:
+- dla chwilowego błędu logowania/cookie aplikacja wykonuje dodatkową próbę odzyskania sesji
+- po udanym retry aplikacja ponawia pobranie strony tego samego serialu
+- po wyczerpaniu limitu prób aplikacja zwraca czytelny błąd końcowy
+- istnieją testy `unittest` dla scenariusza: pierwsza próba nieudana, druga udana
+
+Zakres:
+- dodanie kontrolowanego retry w ścieżce odzyskiwania sesji
+- ponowienie sprawdzenia tego samego serialu po udanym odzyskaniu sesji
+- dodanie logów diagnostycznych z numerem próby
+- rozszerzenie testów jednostkowych o scenariusze retry
+
+Uwagi:
+- zakres wynika z `prd/002-auth-retry-for-first-series-prd.md`
+- poza zakresem: trwały cache cookie między uruchomieniami
+- wdrożono retry odzyskania sesji z limitem prób oraz testy `unittest` dla scenariuszy błędów przejściowych i wyczerpania retry

--- a/STATUS.md
+++ b/STATUS.md
@@ -8,13 +8,17 @@
 - automatyczne logowanie do DramaQueen przez Playwright
 - automatyczne pobranie pełnego zestawu cookie przeglądarki i przekazanie ich do `requests.Session`
 - ponowne logowanie po wykryciu utraty autoryzacji
+- retry odzyskania sesji dla chwilowych błędów logowania/cookie
+- ponowienie sprawdzenia tego samego serialu po udanym odzyskaniu sesji
 
 ## Co jest skończone
 - Milestone 0.5
 - Milestone 1.0
 - Milestone 1.1
+- Milestone 1.2
 - PRD dla automatycznego logowania: `prd/001-auto-cookie-login-prd.md`
-- testy jednostkowe dla logiki sesji i retry logowania
+- PRD retry autoryzacji: `prd/002-auth-retry-for-first-series-prd.md`
+- testy jednostkowe dla logiki sesji, retry logowania i scenariuszy wyczerpania retry
 - smoke test głównego przepływu `process_user()` bez realnego IO
 
 ## Co jest w trakcie
@@ -36,3 +40,7 @@
 - dodano `users.example.json` oraz pozostawiono prawdziwy `users.json` poza repo
 - naprawiono przypadek `City Hunter` przez przekazywanie pełnego zestawu cookie z Playwright do `requests.Session`
 - dodano smoke test `process_user()` oraz domknięto README dla Milestone 1.1
+- wdrożono retry odzyskania sesji (2 próby) w ścieżce sprawdzania serialu
+- dodano testy `unittest` dla scenariusza: pierwsza próba logowania nieudana, druga udana
+- dodano test `unittest` dla scenariusza: sesja nadal wymaga logowania po wyczerpaniu retry
+- potwierdzono poprawny realny przebieg `uv run python main.py` z odzyskaniem sesji i wysyłką e-mail

--- a/main.py
+++ b/main.py
@@ -42,6 +42,7 @@ DEFAULT_SUBMIT_SELECTOR = os.environ.get(
     "DRAMAQUEEN_LOGIN_SUBMIT_SELECTOR",
     "button[type='submit'], input[type='submit'], #wp-submit",
 )
+AUTH_RECOVERY_MAX_ATTEMPTS = 2
 
 COLUMN_ALIASES: Dict[str, List[str]] = {
     "nazwa": ["nazwa", "tytuł", "tytul"],
@@ -465,9 +466,46 @@ def check_series(
                     None,
                     error=f"{series.nazwa}: sesja wygasła, brak skonfigurowanego automatycznego logowania",
                 )
-            authenticator.ensure_session(session, force=True)
-            resp = session.get(series.link, timeout=60)
-            if response_requires_auth(resp):
+            recovered = False
+            last_auth_error: Optional[Exception] = None
+            for attempt in range(1, AUTH_RECOVERY_MAX_ATTEMPTS + 1):
+                logger.warning(
+                    "%s: próba odzyskania sesji %d/%d",
+                    series.nazwa,
+                    attempt,
+                    AUTH_RECOVERY_MAX_ATTEMPTS,
+                )
+                try:
+                    authenticator.ensure_session(session, force=True)
+                    last_auth_error = None
+                except Exception as auth_exc:
+                    last_auth_error = auth_exc
+                    logger.warning(
+                        "%s: nieudana próba odzyskania sesji %d/%d: %s",
+                        series.nazwa,
+                        attempt,
+                        AUTH_RECOVERY_MAX_ATTEMPTS,
+                        auth_exc,
+                    )
+                    continue
+
+                resp = session.get(series.link, timeout=60)
+                if not response_requires_auth(resp):
+                    recovered = True
+                    break
+
+                logger.warning(
+                    "%s: po próbie odzyskania sesji %d/%d strona nadal wymaga logowania",
+                    series.nazwa,
+                    attempt,
+                    AUTH_RECOVERY_MAX_ATTEMPTS,
+                )
+
+            if not recovered:
+                if last_auth_error is not None:
+                    return EpisodeCheckResult(
+                        None, None, error=f"{series.nazwa}: błąd pobierania: {last_auth_error}"
+                    )
                 return EpisodeCheckResult(
                     None,
                     None,

--- a/prd/002-auth-retry-for-first-series-prd.md
+++ b/prd/002-auth-retry-for-first-series-prd.md
@@ -1,0 +1,89 @@
+# PRD: Retry logowania i ponowienie sprawdzenia serialu po błędzie sesji
+
+## Kontekst
+Aktualnie aplikacja odzyskuje sesję dopiero wtedy, gdy przy próbie pobrania strony serialu wykryje brak autoryzacji.
+W praktyce zdarza się błąd nieregularny:
+
+- `Po logowaniu nie znaleziono wymaganych cookie sesyjnych.`
+
+Błąd pojawia się najczęściej przy pierwszym serialu na liście (w bieżącej konfiguracji: `City Hunter`).
+
+## Problem
+Gdy jednorazowo nie powiedzie się krok odzyskania sesji (np. chwilowy problem po stronie logowania/cookie), dany serial dostaje błąd i nie jest ponawiany w tym samym przebiegu.
+
+Skutek:
+- fałszywy błąd dla serialu, mimo że kolejne próby w tej samej sesji lub chwilę później mogą przejść poprawnie
+- wrażenie, że problem dotyczy konkretnego tytułu, podczas gdy przyczyna leży w niestabilności kroku logowania
+
+## Cel
+Zwiększyć odporność przepływu na chwilowe błędy autoryzacji przez kontrolowane retry.
+
+Cel użytkowy:
+- ograniczyć losowe błędy dla pierwszego serialu i zmniejszyć liczbę fałszywych alarmów
+
+Cel techniczny:
+- przy błędzie odzyskania sesji wykonać dodatkową próbę i dopiero potem zwrócić błąd końcowy
+
+## Proponowane rozwiązanie
+Wersja v1 retry:
+1. Dla pojedynczego serialu utrzymać obecny przepływ detekcji braku autoryzacji.
+2. Jeżeli pierwsza próba odzyskania sesji zakończy się błędem związanym z logowaniem/cookie, wykonać ponowną próbę odzyskania sesji.
+3. Po udanym odzyskaniu sesji ponowić pobranie strony serialu.
+4. Dopiero po wyczerpaniu retry zwrócić błąd do raportu.
+
+Dodatkowo:
+- dodać jednoznaczne logowanie numeru próby (attempt 1/2), aby odróżnić chwilową niestabilność od trwałej awarii
+
+## Zakres v1
+Do zakresu tej iteracji wchodzi:
+- retry odzyskania sesji przy błędach logowania/cookie
+- ponowienie sprawdzenia tego samego serialu po udanym odzyskaniu sesji
+- ograniczenie liczby prób (mały, stały limit)
+- czytelne logi diagnostyczne dla prób retry
+- testy `unittest` pokrywające scenariusz: pierwsza próba logowania nieudana, druga udana
+
+## Poza zakresem v1
+Poza zakresem pozostają:
+- trwały cache cookie w pliku między uruchomieniami
+- przebudowa architektury `main.py` na wiele modułów
+- zmiana dostawcy/technologii logowania
+- obsługa CAPTCHA i 2FA
+
+## Wymagania funkcjonalne
+1. Przy chwilowym błędzie logowania/cookie aplikacja wykonuje co najmniej jedną dodatkową próbę odzyskania sesji.
+2. Po udanym retry aplikacja ponawia pobranie strony tego samego serialu.
+3. Jeśli retry się nie powiedzie, użytkownik dostaje błąd końcowy jak dotychczas, ale z pełniejszym kontekstem logów.
+4. Retry nie może prowadzić do nieskończonej pętli.
+
+## Wymagania niefunkcjonalne
+- retry ma mieć stały, mały limit prób (deterministyczny czas wykonania)
+- brak nowych sekretów i brak przechowywania sesji w repozytorium
+- zgodność z uruchamianiem przez `uv`
+- testy bez realnego IO (stuby/fake’i)
+
+## Wpływ na istniejący system
+- zmiana dotyczy wyłącznie ścieżki obsługi błędów autoryzacji
+- główny model działania (Google Sheets -> requests -> parser -> e-mail) pozostaje bez zmian
+- brak zmiany modelu konfiguracji środowiskowej w tej iteracji
+
+## Kryteria sukcesu
+Funkcjonalność będzie uznana za skuteczną, gdy:
+- pojedyncza chwilowa awaria logowania nie kończy sprawdzania danego serialu błędem
+- liczba losowych błędów podobnych do `Po logowaniu nie znaleziono wymaganych cookie sesyjnych` spada
+- zachowanie przy trwałym błędzie logowania pozostaje czytelne i przewidywalne
+
+## Kryteria akceptacji
+1. Scenariusz testowy: pierwsza próba odzyskania sesji kończy się błędem, druga się udaje, serial jest poprawnie sprawdzony.
+2. Scenariusz testowy: wszystkie próby odzyskania sesji nieudane, serial kończy się błędem końcowym.
+3. W logach widoczna jest liczba wykonanych prób retry.
+4. Brak regresji dla istniejących testów smoke.
+
+## Ryzyka i ograniczenia
+- retry może wydłużyć czas pojedynczego przebiegu
+- jeśli problem jest trwały (np. zmiana formularza logowania), retry nie rozwiąże źródła problemu
+- zbyt agresywny retry mógłby zwiększyć liczbę prób logowania; dlatego limit musi pozostać niski
+
+## Założenia
+- obecny błąd ma charakter nieregularny (intermittent), a nie permanentny
+- druga próba logowania ma realną szansę powodzenia
+- wdrożenie tej iteracji obejmuje dokumentację PRD; implementacja nastąpi w kolejnym kroku

--- a/spec.md
+++ b/spec.md
@@ -24,6 +24,11 @@ Wdrożone rozszerzenie zakresu (PRD `001-auto-cookie-login-prd.md`):
 - samodzielne pobieranie i odświeżanie cookie sesyjnych
 - przekazanie aktualnych cookie do istniejącego przepływu opartego na `requests.Session`
 
+Wdrożone rozszerzenie zakresu (PRD `002-auth-retry-for-first-series-prd.md`):
+- kontrolowane retry odzyskania sesji po chwilowym błędzie logowania/cookie
+- ponowienie sprawdzenia tego samego serialu po udanym odzyskaniu sesji
+- ograniczony limit prób i czytelne logowanie numeru próby
+
 Poza zakresem:
 - interfejs WWW, CLI z parserem argumentów lub panel administracyjny
 - trwała baza danych poza Google Sheets
@@ -54,13 +59,17 @@ Aplikacja obecnie nie robi:
 - nie zapisuje historii zmian ani audytu operacji
 - nie rozróżnia typów błędów na poziomie retry/backoff/circuit breaker
 - nie waliduje konfiguracji w sposób formalny przed startem
-- nie posiada testów automatycznych ani warstwy stubów/fake’ów dla smoke testów
 
 Wdrożone rozszerzenie wynikające z PRD `001-auto-cookie-login-prd.md`:
 - automatyczne logowanie przez rzeczywistą przeglądarkę sterowaną Playwright
 - wykrywanie utraty autoryzacji i automatyczne odświeżanie sesji
 - pozostawienie ręcznie podanych cookie wyłącznie jako trybu awaryjnego
 - przekazywanie pełnego zestawu cookie z przeglądarki do `requests.Session`, aby zachować dostęp do stron wymagających dodatkowego stanu sesji
+
+Wdrożone rozszerzenie wynikające z PRD `002-auth-retry-for-first-series-prd.md`:
+- dodatkowa próba odzyskania sesji dla chwilowych błędów logowania/cookie
+- ponowienie pobrania strony tego samego serialu po udanym retry
+- zakończenie błędem dopiero po wyczerpaniu limitu prób
 
 ---
 
@@ -82,6 +91,7 @@ Architektura jest monolityczna i skryptowa. Cała logika znajduje się w jednym 
 - dla każdego użytkownika skrypt otwiera wskazany arkusz i zakładkę
 - przed pobieraniem stron aplikacja będzie weryfikować, czy ma ważną sesję do serwisu źródłowego
 - jeśli sesja będzie nieważna, komponent Playwright wykona logowanie i zasili `requests.Session` pełnym zestawem aktualnych cookie z kontekstu przeglądarki
+- dla błędów odzyskiwania sesji aplikacja wykonuje ograniczony retry, zanim zgłosi błąd końcowy (wdrożone w PRD `002-auth-retry-for-first-series-prd.md`)
 - z arkusza pobierane są wszystkie wiersze i mapowane do modelu `SeriesRow`
 - dla każdego aktywnego serialu wykonywane jest żądanie HTTP do strony odcinków
 - HTML jest parsowany do wyniku `EpisodeCheckResult`
@@ -114,6 +124,7 @@ Obecne ograniczenie architektoniczne:
 - moduł logowania Playwright: uzyskanie cookie po zalogowaniu i przekazanie ich do sesji HTTP
 - moduł translacji sesji przeglądarki: przeniesienie pełnego zestawu cookie do klienta `requests`
 - mechanizm walidacji sesji: wykrycie utraty autoryzacji i wywołanie ponownego logowania
+- mechanizm retry autoryzacji: ponowna próba odzyskania sesji i ponowienie sprawdzenia tego samego serialu po chwilowej awarii logowania/cookie
 
 Zewnętrzne zależności wykonawcze:
 - Google Sheets API przez konto serwisowe
@@ -201,6 +212,13 @@ Zewnętrzne zależności wykonawcze:
     Konsekwencje:
     Jeśli serwis wymusi dodatkowe kroki uwierzytelnienia, konieczna będzie osobna decyzja produktowa i techniczna.
 
+12. Decyzja (dotyczy PRD: `002-auth-retry-for-first-series-prd.md`):
+    Wprowadzono ograniczony retry odzyskania sesji oraz ponowienie pobrania strony tego samego serialu po chwilowym błędzie logowania/cookie.
+    Uzasadnienie:
+    Obserwowane błędy mają charakter nieregularny, a pojedyncza nieudana próba logowania może fałszywie oznaczyć pierwszy serial na liście jako niedostępny.
+    Konsekwencje:
+    Czas pojedynczego przebiegu może wzrosnąć o czas dodatkowej próby, ale liczba fałszywych błędów dla pojedynczych seriali powinna spaść.
+
 ---
 
 ## Jakość i kryteria akceptacji
@@ -212,8 +230,6 @@ Wymagania jakościowe dla aktualnego stanu projektu:
 - logowanie automatyczne odzyskuje sesję bez ręcznej aktualizacji cookie przez użytkownika
 
 Luki jakościowe wymagające domknięcia w kolejnych pracach:
-- brak testów `unittest`, mimo że są wymagane operacyjnie w `AGENTS.md`
-- brak smoke testów bez IO
 - brak formalnej walidacji konfiguracji wejściowej
 - brak pełnej dokumentacji wszystkich wymaganych zmiennych środowiskowych w `README.md`
 - brak smoke testu dla pełnego przebiegu z nowym mechanizmem sesji
@@ -230,6 +246,12 @@ Minimalne kryteria akceptacji dla rozszerzenia z PRD `001-auto-cookie-login-prd.
 - pełny zestaw cookie z przeglądarki zachowuje dostęp także do stron wymagających dodatkowego stanu sesji, takich jak `City Hunter`
 - po wygaśnięciu sesji aplikacja potrafi ponowić logowanie automatycznie
 - błędy logowania są czytelnie raportowane i nie pozostają „ciche”
+
+Minimalne kryteria akceptacji dla rozszerzenia z PRD `002-auth-retry-for-first-series-prd.md`:
+- przy chwilowym błędzie odzyskania sesji aplikacja wykonuje dodatkową próbę logowania zamiast kończyć od razu błędem
+- po udanym retry aplikacja ponawia sprawdzenie tego samego serialu i zwraca wynik bez błędu technicznego
+- po wyczerpaniu limitu retry aplikacja raportuje błąd końcowy w sposób czytelny
+- testy `unittest` obejmują scenariusz: pierwsza próba nieudana, druga udana
 
 ---
 
@@ -249,10 +271,11 @@ Minimalne kryteria akceptacji dla rozszerzenia z PRD `001-auto-cookie-login-prd.
 - Najbliższym zadaniem porządkującym powinno być urealnienie `ROADMAP.md` i `STATUS.md` względem obecnego kodu.
 - Ta specyfikacja opisuje stan bieżącej implementacji, a nie docelowy, pełny plan rozwoju.
 - PRD `001-auto-cookie-login-prd.md` został zrealizowany dla Milestone 1.0 i wprowadził automatyczne logowanie oraz odświeżanie sesji przez Playwright.
+- PRD `002-auth-retry-for-first-series-prd.md` został zrealizowany i dodał odporność na chwilowe błędy logowania przez kontrolowane retry oraz ponowienie sprawdzenia serialu.
 
 ---
 
 ## Status specyfikacji
 - Data utworzenia: 2026-03-21
-- Ostatnia aktualizacja: 2026-03-21
-- Aktualny zakres obowiązywania: bieżąca implementacja skryptu `main.py`, konfiguracja z `pyproject.toml`, opis projektu z `README.md` oraz wdrożone logowanie Playwright z PRD `001-auto-cookie-login-prd.md`
+- Ostatnia aktualizacja: 2026-03-23
+- Aktualny zakres obowiązywania: bieżąca implementacja skryptu `main.py`, konfiguracja z `pyproject.toml`, opis projektu z `README.md`, wdrożone logowanie Playwright z PRD `001-auto-cookie-login-prd.md` oraz wdrożone retry autoryzacji z PRD `002-auth-retry-for-first-series-prd.md`

--- a/tests/test_auth_session.py
+++ b/tests/test_auth_session.py
@@ -32,6 +32,19 @@ class FakeAuthenticator:
         session.cookies.set("wordpress_logged_in_test", "ok", domain="www.dramaqueen.pl")
 
 
+class FlakyAuthenticator:
+    def __init__(self, fail_attempts=1, message="Po logowaniu nie znaleziono wymaganych cookie sesyjnych."):
+        self.calls = 0
+        self.fail_attempts = fail_attempts
+        self.message = message
+
+    def ensure_session(self, session, force=False):
+        self.calls += 1
+        if self.calls <= self.fail_attempts:
+            raise RuntimeError(self.message)
+        session.cookies.set("wordpress_logged_in_test", "ok", domain="www.dramaqueen.pl")
+
+
 class AuthSessionTests(unittest.TestCase):
     def test_extract_auth_cookies_filters_only_session_cookies(self):
         cookies = [
@@ -125,6 +138,80 @@ class AuthSessionTests(unittest.TestCase):
         result = main.check_series(session, series)
 
         self.assertIn("brak skonfigurowanego automatycznego logowania", result.error or "")
+
+    def test_check_series_retries_auth_recovery_after_transient_failure(self):
+        login_page = FakeResponse(
+            url="https://www.dramaqueen.pl/wp-login.php?redirect_to=%2Fserial",
+            text='<input id="user_login" name="log"><input id="user_pass" name="pwd"><input id="wp-submit">',
+        )
+        episode_page = FakeResponse(
+            text="""
+            <p class="toggler">Odcinek 9</p>
+            <p class="toggler"><img src="locked.png">Odcinek 10</p>
+            """,
+        )
+        session = FakeSession([login_page, episode_page])
+        authenticator = FlakyAuthenticator(fail_attempts=1)
+        series = main.SeriesRow(
+            row_idx=2,
+            nazwa="City Hunter",
+            link="https://www.dramaqueen.pl/city-hunter",
+            obejrzany_odcinek=7,
+            odcinek_na_stronie=7,
+            liczba_odcinków=20,
+        )
+
+        result = main.check_series(session, series, authenticator)
+
+        self.assertIsNone(result.error)
+        self.assertEqual(9, result.latest_ready)
+        self.assertEqual(10, result.max_found)
+        self.assertEqual(2, authenticator.calls)
+
+    def test_check_series_returns_error_after_exhausted_auth_retries(self):
+        login_page = FakeResponse(
+            url="https://www.dramaqueen.pl/wp-login.php?redirect_to=%2Fserial",
+            text='<input id="user_login" name="log"><input id="user_pass" name="pwd"><input id="wp-submit">',
+        )
+        session = FakeSession([login_page])
+        authenticator = FlakyAuthenticator(fail_attempts=5)
+        series = main.SeriesRow(
+            row_idx=2,
+            nazwa="City Hunter",
+            link="https://www.dramaqueen.pl/city-hunter",
+            obejrzany_odcinek=7,
+            odcinek_na_stronie=7,
+            liczba_odcinków=20,
+        )
+
+        result = main.check_series(session, series, authenticator)
+
+        self.assertIsNotNone(result.error)
+        self.assertIn("błąd pobierania", result.error or "")
+        self.assertIn("Po logowaniu nie znaleziono wymaganych cookie sesyjnych", result.error or "")
+        self.assertEqual(main.AUTH_RECOVERY_MAX_ATTEMPTS, authenticator.calls)
+
+    def test_check_series_returns_auth_recovery_error_when_page_still_requires_auth(self):
+        login_page = FakeResponse(
+            url="https://www.dramaqueen.pl/wp-login.php?redirect_to=%2Fserial",
+            text='<input id="user_login" name="log"><input id="user_pass" name="pwd"><input id="wp-submit">',
+        )
+        session = FakeSession([login_page, login_page, login_page])
+        authenticator = FakeAuthenticator()
+        series = main.SeriesRow(
+            row_idx=2,
+            nazwa="City Hunter",
+            link="https://www.dramaqueen.pl/city-hunter",
+            obejrzany_odcinek=7,
+            odcinek_na_stronie=7,
+            liczba_odcinków=20,
+        )
+
+        result = main.check_series(session, series, authenticator)
+
+        self.assertIsNotNone(result.error)
+        self.assertIn("nie udało się odzyskać zalogowanej sesji", result.error or "")
+        self.assertEqual(main.AUTH_RECOVERY_MAX_ATTEMPTS, authenticator.calls)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Zakres\n- wdrożenie retry odzyskania sesji (2 próby) w ścieżce sprawdzania serialu\n- ponowienie pobrania strony serialu po udanym odzyskaniu sesji\n- testy jednostkowe dla scenariuszy błędów przejściowych i wyczerpania retry\n- aktualizacja dokumentacji: ROADMAP, STATUS, spec, README, nowy PRD 002\n\n## Walidacja\n- uv run python -m unittest discover -s tests -p "test_*.py"\n- realny przebieg: uv run python main.py (exit code 0)\n