### PR TITLE
Fix strict episode label parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Skrypt sprawdzający nowe odcinki K-dram w arkuszu Google Sheets i wysyłający 
 Obsługuje automatyczne logowanie do DramaQueen przez Playwright, więc nie trzeba już ręcznie odnawiać cookie w `.env`.
 Po zalogowaniu przenosi do `requests.Session` pełny zestaw cookie z przeglądarki, co jest potrzebne dla części stron takich jak `City Hunter`.
 Dla chwilowych problemów logowania działa retry odzyskania sesji (2 próby), żeby ograniczyć losowe błędy pojedynczych seriali.
+Parser odcinków liczy jako istniejące wyłącznie etykiety dokładnie równe `Odcinek <numer>`, więc dopiski informacyjne typu `Premiera w Korei: ...` nie powodują już fałszywych wykryć.
 
 ## Uruchamianie
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -108,3 +108,27 @@ Uwagi:
 - zakres wynika z `prd/002-auth-retry-for-first-series-prd.md`
 - poza zakresem: trwały cache cookie między uruchomieniami
 - wdrożono retry odzyskania sesji z limitem prób oraz testy `unittest` dla scenariuszy błędów przejściowych i wyczerpania retry
+
+---
+
+## Milestone 1.3: Ścisłe wykrywanie odcinków bez dodatkowych opisów (done)
+
+Cel:
+- wyeliminować fałszywe wykrycia odcinków dla etykiet zawierających dodatkowy opis, takich jak `Premiera w Korei: ...`
+- uznawać za istniejące wyłącznie odcinki oznaczone dokładnie jako `Odcinek <numer>`
+
+Definition of Done:
+- parser uznaje za odcinek tylko element, którego pełny tekst po normalizacji jest dokładnie równy `Odcinek <numer>`
+- etykiety z dodatkowymi dopiskami nie wpływają ani na `latest_ready`, ani na `max_found`
+- istnieją testy `unittest` dla scenariuszy z dodatkowymi opisami oraz scenariuszy mieszanych
+- brak regresji dla istniejących testów prostych etykiet i blokad z obrazkiem
+
+Zakres:
+- doprecyzowanie logiki parsowania etykiet odcinków
+- utrzymanie obecnego rozróżnienia między odcinkiem gotowym i zablokowanym przez obrazek
+- dodanie testów dla etykiet typu `Odcinek 6 Premiera w Korei: 31.03.2026`
+
+Uwagi:
+- zakres wynika z `prd/003-strict-episode-label-parsing-prd.md`
+- wdrożono ścisłe dopasowanie etykiet `Odcinek <numer>` oraz testy dla przypadków z dodatkowymi opisami
+- potwierdzony przypadek błędu dotyczył strony `Climax`, gdzie `Odcinek 6 Premiera w Korei: 31.03.2026` był błędnie liczony jako dostępny odcinek

--- a/STATUS.md
+++ b/STATUS.md
@@ -10,21 +10,26 @@
 - ponowne logowanie po wykryciu utraty autoryzacji
 - retry odzyskania sesji dla chwilowych błędów logowania/cookie
 - ponowienie sprawdzenia tego samego serialu po udanym odzyskaniu sesji
+- ścisłe wykrywanie odcinków tylko dla etykiet dokładnie równych `Odcinek <numer>`
 
 ## Co jest skończone
 - Milestone 0.5
 - Milestone 1.0
 - Milestone 1.1
 - Milestone 1.2
+- Milestone 1.3
 - PRD dla automatycznego logowania: `prd/001-auto-cookie-login-prd.md`
 - PRD retry autoryzacji: `prd/002-auth-retry-for-first-series-prd.md`
+- PRD ścisłego parsowania etykiet odcinków: `prd/003-strict-episode-label-parsing-prd.md`
 - testy jednostkowe dla logiki sesji, retry logowania i scenariuszy wyczerpania retry
 - smoke test głównego przepływu `process_user()` bez realnego IO
+- testy jednostkowe i smoke test dla etykiet odcinków z dodatkowymi opisami
 
 ## Co jest w trakcie
 - brak aktywnego wdrożenia; bieżąca praca została domknięta na poziomie kodu i dokumentacji
 
 ## Co jest następne
+- brak zaplanowanych milestone'ów; kolejny zakres wymaga dopisania nowego PRD lub milestone'u
 - doprecyzowanie przykładowej konfiguracji użytkowników na bazie `users.example.json`
 - ewentualne wydzielenie logiki uwierzytelnienia z `main.py` bez zmiany zachowania
 - ewentualna obsługa CAPTCHA i 2FA jako osobny zakres prac
@@ -44,3 +49,5 @@
 - dodano testy `unittest` dla scenariusza: pierwsza próba logowania nieudana, druga udana
 - dodano test `unittest` dla scenariusza: sesja nadal wymaga logowania po wyczerpaniu retry
 - potwierdzono poprawny realny przebieg `uv run python main.py` z odzyskaniem sesji i wysyłką e-mail
+- wdrożono ścisłe parsowanie etykiet odcinków i ignorowanie dopisków typu `Premiera w Korei: ...`
+- dodano testy `unittest` i smoke test dla przypadku `Climax`, który wcześniej fałszywie wykrywał nowy odcinek

--- a/main.py
+++ b/main.py
@@ -22,7 +22,7 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-EPISODE_ANY_RE = re.compile(r"Odcinek\s*(\d+)", re.IGNORECASE)
+EPISODE_LABEL_RE = re.compile(r"^Odcinek\s+(\d+)$", re.IGNORECASE)
 
 DEFAULT_USER_AGENT = (
     "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
@@ -276,7 +276,7 @@ def build_email_html(new_items: List[dict], problems: List[str]) -> str:
 
 
 def extract_episode_number(text: str) -> Optional[int]:
-    m = EPISODE_ANY_RE.search(text)
+    m = EPISODE_LABEL_RE.fullmatch((text or "").strip())
     if m:
         try:
             return int(m.group(1))

--- a/prd/003-strict-episode-label-parsing-prd.md
+++ b/prd/003-strict-episode-label-parsing-prd.md
@@ -1,0 +1,96 @@
+# PRD: Ścisłe wykrywanie odcinków bez dodatkowych opisów
+
+## Kontekst
+Aktualnie parser odcinków uznaje element strony za odcinek, jeśli jego tekst zawiera wzorzec `Odcinek <numer>`.
+To podejście jest zbyt szerokie, ponieważ niektóre labelki zawierają numer odcinka oraz dodatkowy opis informacyjny, mimo że odcinek nie jest jeszcze realnie dostępny do oglądania.
+
+Potwierdzony przypadek produkcyjny:
+- strona: `https://www.dramaqueen.pl/drama/koreanska/climax/`
+- aktualny label: `Odcinek 6 Premiera w Korei: 31.03.2026`
+- obecny parser błędnie uznaje ten element za istniejący odcinek i zwraca `latest_ready=6`, `max_found=6`
+
+## Problem
+Nie wszystkie labelki z numerem odcinka oznaczają realnie istniejący odcinek na stronie.
+
+W efekcie:
+- arkusz może zostać zaktualizowany zbyt wcześnie
+- użytkownik dostaje fałszywe powiadomienia o nowych odcinkach
+- stan obejrzenia zaczyna rozjeżdżać się z rzeczywistą dostępnością odcinków
+
+## Cel
+Zawęzić regułę parsowania tak, aby za istniejące były uznawane wyłącznie te odcinki, których label po normalizacji jest dokładnie równy `Odcinek <numer>`.
+
+Cel użytkowy:
+- użytkownik ma dostawać tylko realnie dostępne odcinki, bez zapowiedzi i etykiet informacyjnych
+
+Cel techniczny:
+- parser ma odrzucać elementy, które zawierają dodatkowy opis poza samym `Odcinek <numer>`
+
+## Proponowane rozwiązanie
+Wersja v1 fixu:
+1. Zachować obecne wyszukiwanie kandydatów w elementach `p.toggler`.
+2. Znormalizować tekst elementu tak jak obecnie, przez `get_text(" ", strip=True)`.
+3. Uznawać element za odcinek tylko wtedy, gdy cały znormalizowany tekst pasuje dokładnie do wzorca `Odcinek <numer>`.
+4. Elementy z dodatkowym tekstem mają zostać odrzucone, nawet jeśli zawierają numer odcinka.
+5. Obecna reguła z obrazkiem blokady pozostaje bez zmiany:
+   - element bez obrazka może podnosić `latest_ready`
+   - element z obrazkiem może podnosić tylko `max_found`
+
+Przykłady:
+- poprawne: `Odcinek 5`
+- niepoprawne: `Odcinek 6 Premiera w Korei: 31.03.2026`
+- niepoprawne: `Odcinek 6 - wkrótce`
+- niepoprawne: `Odcinek 6 Napisy wkrótce`
+
+## Zakres v1
+Do zakresu tej iteracji wchodzi:
+- doprecyzowanie reguły wykrywania odcinków do pełnego dopasowania całego labela
+- odrzucanie etykiet z dodatkowymi opisami, nawet jeśli zawierają numer odcinka
+- utrzymanie obecnej logiki rozróżnienia między odcinkiem gotowym a zablokowanym przez obecność obrazka
+- dodanie testów `unittest` dla etykiet z dodatkowymi dopiskami
+
+## Poza zakresem v1
+Poza zakresem pozostają:
+- refaktoryzacja `main.py`
+- zmiana selektorów HTML lub źródła danych
+- próba interpretowania innych opisów jako stanów pośrednich
+- heurystyki dla innych formatów niż dokładne `Odcinek <numer>`
+
+## Wymagania funkcjonalne
+1. Element ma być liczony jako odcinek tylko wtedy, gdy cały jego tekst jest dokładnie równy `Odcinek <numer>`.
+2. Element zawierający dodatkowy tekst nie może wpływać ani na `latest_ready`, ani na `max_found`.
+3. Dla poprawnych prostych etykiet obecne zachowanie ma pozostać bez zmiany.
+4. Obecna detekcja zablokowanego odcinka przez obecność obrazka ma pozostać bez zmiany.
+
+## Wymagania niefunkcjonalne
+- brak nowych zależności
+- brak zmian w konfiguracji środowiskowej
+- testy bez realnego IO
+- zgodność z obecnym uruchamianiem przez `uv`
+
+## Wpływ na istniejący system
+- zmiana dotyczy wyłącznie logiki parsowania HTML dla odcinków
+- logowanie, Google Sheets, e-mail i mechanizm sesji pozostają bez zmian
+- wynik parsowania ma być bardziej zachowawczy i bliższy rzeczywistej dostępności odcinków
+
+## Kryteria sukcesu
+Funkcjonalność będzie uznana za skuteczną, gdy:
+- labelki z dodatkowymi dopiskami nie będą już podnosić numeru wykrytego odcinka
+- przypadek `Climax` przestanie fałszywie wykrywać odcinek 6 jako dostępny
+- proste przypadki `Odcinek <numer>` dalej będą parsowane poprawnie
+
+## Kryteria akceptacji
+1. Scenariusz: `Odcinek 1`, `Odcinek 2`, `Odcinek 3` z obrazkiem blokady daje `latest_ready=2`, `max_found=3`.
+2. Scenariusz: `Odcinek 6 Premiera w Korei: 31.03.2026` jest ignorowany i nie podnosi żadnego wyniku.
+3. Scenariusz mieszany: `Odcinek 5`, `Odcinek 6 Premiera w Korei: 31.03.2026`, `Odcinek 7` z obrazkiem blokady daje `latest_ready=5`, `max_found=7`.
+4. Scenariusz bez żadnego dokładnego labela `Odcinek <numer>` nadal kończy się błędem `Nie znaleziono nagłówków odcinków.`
+
+## Ryzyka i ograniczenia
+- jeśli serwis zacznie oznaczać realnie dostępne odcinki dodatkowymi dopiskami, nowa reguła może stać się zbyt restrykcyjna
+- parser nadal pozostaje zależny od struktury HTML serwisu
+- rozwiązanie świadomie preferuje fałszywy brak odcinka zamiast fałszywego wykrycia odcinka
+
+## Założenia
+- obowiązującym formatem realnie dostępnego odcinka jest dokładnie `Odcinek <numer>`
+- dodatkowy tekst w tym samym labelu oznacza informację pomocniczą, zapowiedź albo inny stan niż realna dostępność
+- wdrożenie tej iteracji obejmuje dokumentację PRD; implementacja nastąpi w kolejnym kroku

--- a/spec.md
+++ b/spec.md
@@ -29,6 +29,11 @@ Wdrożone rozszerzenie zakresu (PRD `002-auth-retry-for-first-series-prd.md`):
 - ponowienie sprawdzenia tego samego serialu po udanym odzyskaniu sesji
 - ograniczony limit prób i czytelne logowanie numeru próby
 
+Wdrożone rozszerzenie zakresu (PRD `003-strict-episode-label-parsing-prd.md`):
+- ścisłe wykrywanie wyłącznie etykiet dokładnie równych `Odcinek <numer>`
+- odrzucanie etykiet z dodatkowymi opisami, takimi jak `Premiera w Korei: ...`
+- ograniczenie fałszywych wykryć odcinków jeszcze niedostępnych do oglądania
+
 Poza zakresem:
 - interfejs WWW, CLI z parserem argumentów lub panel administracyjny
 - trwała baza danych poza Google Sheets
@@ -70,6 +75,10 @@ Wdrożone rozszerzenie wynikające z PRD `002-auth-retry-for-first-series-prd.md
 - dodatkowa próba odzyskania sesji dla chwilowych błędów logowania/cookie
 - ponowienie pobrania strony tego samego serialu po udanym retry
 - zakończenie błędem dopiero po wyczerpaniu limitu prób
+
+Wdrożone rozszerzenie wynikające z PRD `003-strict-episode-label-parsing-prd.md`:
+- parser ma uznawać za istniejący odcinek tylko taki element HTML, którego pełny tekst po normalizacji jest dokładnie równy `Odcinek <numer>`
+- elementy zawierające dodatkowy opis, nawet jeśli zawierają numer odcinka, nie mają wpływać na `latest_ready` ani `max_found`
 
 ---
 
@@ -125,6 +134,7 @@ Obecne ograniczenie architektoniczne:
 - moduł translacji sesji przeglądarki: przeniesienie pełnego zestawu cookie do klienta `requests`
 - mechanizm walidacji sesji: wykrycie utraty autoryzacji i wywołanie ponownego logowania
 - mechanizm retry autoryzacji: ponowna próba odzyskania sesji i ponowienie sprawdzenia tego samego serialu po chwilowej awarii logowania/cookie
+- parser odcinków: pełne dopasowanie całego labela zamiast częściowego wykrywania numeru
 
 Zewnętrzne zależności wykonawcze:
 - Google Sheets API przez konto serwisowe
@@ -218,6 +228,13 @@ Zewnętrzne zależności wykonawcze:
     Obserwowane błędy mają charakter nieregularny, a pojedyncza nieudana próba logowania może fałszywie oznaczyć pierwszy serial na liście jako niedostępny.
     Konsekwencje:
     Czas pojedynczego przebiegu może wzrosnąć o czas dodatkowej próby, ale liczba fałszywych błędów dla pojedynczych seriali powinna spaść.
+
+13. Decyzja (dotyczy PRD: `003-strict-episode-label-parsing-prd.md`):
+    Parser odcinków ma uznawać za istniejące wyłącznie etykiety dokładnie równe `Odcinek <numer>`, po normalizacji tekstu elementu HTML.
+    Uzasadnienie:
+    Częściowe dopasowanie do wzorca `Odcinek <numer>` powoduje fałszywe wykrycia dla etykiet informacyjnych, takich jak `Odcinek 6 Premiera w Korei: 31.03.2026`.
+    Konsekwencje:
+    Parser stanie się bardziej restrykcyjny i może pominąć odcinki, jeśli serwis zacznie dopisywać dodatkowy tekst także przy realnie dostępnych odcinkach, ale ograniczy błędne aktualizacje arkusza i fałszywe powiadomienia.
 
 ---
 

--- a/tests/test_auth_session.py
+++ b/tests/test_auth_session.py
@@ -46,6 +46,39 @@ class FlakyAuthenticator:
 
 
 class AuthSessionTests(unittest.TestCase):
+    def test_extract_episode_number_accepts_only_exact_episode_label(self):
+        self.assertEqual(6, main.extract_episode_number("Odcinek 6"))
+        self.assertEqual(6, main.extract_episode_number("  Odcinek 6  "))
+        self.assertIsNone(
+            main.extract_episode_number("Odcinek 6 Premiera w Korei: 31.03.2026")
+        )
+        self.assertIsNone(main.extract_episode_number("Odcinek 6 - wkrótce"))
+
+    def test_find_episodes_ignores_labels_with_additional_description(self):
+        html = """
+        <p class="toggler">Odcinek 5</p>
+        <p class="toggler">Odcinek 6 Premiera w Korei: 31.03.2026</p>
+        <p class="toggler"><img src="locked.png">Odcinek 7</p>
+        """
+
+        result = main.find_episodes(html)
+
+        self.assertIsNone(result.error)
+        self.assertEqual(5, result.latest_ready)
+        self.assertEqual(7, result.max_found)
+
+    def test_find_episodes_returns_error_when_only_descriptive_labels_exist(self):
+        html = """
+        <p class="toggler">Odcinek 6 Premiera w Korei: 31.03.2026</p>
+        <p class="toggler">Premiera w Korei: 31.03.2026</p>
+        """
+
+        result = main.find_episodes(html)
+
+        self.assertEqual("Nie znaleziono nagłówków odcinków.", result.error)
+        self.assertIsNone(result.latest_ready)
+        self.assertIsNone(result.max_found)
+
     def test_extract_auth_cookies_filters_only_session_cookies(self):
         cookies = [
             {"name": "PHPSESSID", "value": "abc"},

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -132,6 +132,67 @@ class SmokeFlowTests(unittest.TestCase):
             main.open_sheet = original_open_sheet
             main.send_email = original_send_email
 
+    def test_process_user_ignores_descriptive_label_and_does_not_false_positive(self):
+        login_page = FakeResponse(
+            url="https://www.dramaqueen.pl/wp-login.php?redirect_to=%2Fserial",
+            text='<input id="user_login" name="log"><input id="user_pass" name="pwd"><input id="wp-submit">',
+        )
+        episode_page = FakeResponse(
+            url="https://www.dramaqueen.pl/drama/koreanska/climax/",
+            text="""
+            <p class="toggler">Odcinek 5</p>
+            <p class="toggler">Odcinek 6 Premiera w Korei: 31.03.2026</p>
+            """,
+        )
+        session = FakeSession([login_page, episode_page])
+        authenticator = FakeAuthenticator()
+        worksheet = FakeWorksheet()
+        worksheet.values[1][0] = "Climax"
+        worksheet.values[1][1] = "https://www.dramaqueen.pl/drama/koreanska/climax/"
+        worksheet.values[1][2] = "5"
+        worksheet.values[1][3] = "5"
+        sent_messages = []
+
+        original_authenticate_gspread = main.authenticate_gspread
+        original_open_sheet = main.open_sheet
+        original_send_email = main.send_email
+        try:
+            main.authenticate_gspread = lambda service_account_file: object()
+            main.open_sheet = lambda gc, spreadsheet_title, worksheet_title: (
+                object(),
+                worksheet,
+            )
+
+            def fake_send_email(subject, html_body, email_to):
+                sent_messages.append(
+                    {
+                        "subject": subject,
+                        "html_body": html_body,
+                        "email_to": email_to,
+                    }
+                )
+
+            main.send_email = fake_send_email
+
+            cfg = main.UserConfig(
+                sheet_title="dramy",
+                worksheet_title="Arkusz1",
+                email_to="example@example.com",
+                always_send=False,
+                service_account_file="service_account.json",
+            )
+
+            result = main.process_user(cfg, session, authenticator)
+
+            self.assertEqual(0, result)
+            self.assertEqual(1, authenticator.calls)
+            self.assertEqual([], worksheet.updated_cells)
+            self.assertEqual([], sent_messages)
+        finally:
+            main.authenticate_gspread = original_authenticate_gspread
+            main.open_sheet = original_open_sheet
+            main.send_email = original_send_email
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- count only exact `Odcinek <numer>` labels as real episodes
- ignore descriptive labels like `Premiera w Korei: ...`
- add unit and smoke coverage for the `Climax` case

## Verification
- uv run python -m unittest discover -s tests -p "test_*.py"
- uv run python main.py
- verified `Climax` in Google Sheets stayed at `odcinek_na_stronie=2` after the real run