### PR TITLE
Handle final episode labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Obsługuje automatyczne logowanie do DramaQueen przez Playwright, więc nie trze
 Po zalogowaniu przenosi do `requests.Session` pełny zestaw cookie z przeglądarki, co jest potrzebne dla części stron takich jak `City Hunter`.
 Dla chwilowych problemów logowania działa retry odzyskania sesji (2 próby), żeby ograniczyć losowe błędy pojedynczych seriali.
 Parser odcinków liczy jako istniejące wyłącznie etykiety dokładnie równe `Odcinek <numer>`, więc dopiski informacyjne typu `Premiera w Korei: ...` nie powodują już fałszywych wykryć.
+Dopuszcza też polskie etykiety finałowe typu `Odcinek <numer> - Finał`, żeby ostatnie odcinki seriali były wykrywane bez ręcznej korekty arkusza.
 
 ## Uruchamianie
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -132,3 +132,27 @@ Uwagi:
 - zakres wynika z `prd/003-strict-episode-label-parsing-prd.md`
 - wdrożono ścisłe dopasowanie etykiet `Odcinek <numer>` oraz testy dla przypadków z dodatkowymi opisami
 - potwierdzony przypadek błędu dotyczył strony `Climax`, gdzie `Odcinek 6 Premiera w Korei: 31.03.2026` był błędnie liczony jako dostępny odcinek
+
+---
+
+## Milestone 1.4: Obsługa finałowych etykiet odcinków (done)
+
+Cel:
+- wykrywać realnie dostępne finały oznaczone jako `Odcinek <numer> - Finał`
+- zachować ochronę przed fałszywymi wykryciami dopisków informacyjnych
+
+Definition of Done:
+- parser akceptuje `Odcinek <numer> - Finał` oraz warianty spacji i wielkości liter słowa `Finał`
+- parser nadal odrzuca etykiety typu `Odcinek <numer> Premiera w Korei: ...`
+- odblokowany finał podnosi `latest_ready`
+- finał z obrazkiem blokady nie podnosi `latest_ready`
+- istnieją testy `unittest` dla przypadku `Climax` i etykiet finałowych
+
+Zakres:
+- rozszerzenie regexu parsującego etykiety odcinków
+- dodanie testów jednostkowych dla wariantów finału
+- dodanie smoke testu procesu dla `Climax` z `Odcinek 10 - Finał`
+
+Uwagi:
+- zakres wynika z `prd/004-final-episode-label-parsing-prd.md`
+- poza zakresem: dowolne sufiksy po numerze odcinka oraz angielskie warianty `Final`/`Finale`

--- a/STATUS.md
+++ b/STATUS.md
@@ -11,6 +11,7 @@
 - retry odzyskania sesji dla chwilowych błędów logowania/cookie
 - ponowienie sprawdzenia tego samego serialu po udanym odzyskaniu sesji
 - ścisłe wykrywanie odcinków tylko dla etykiet dokładnie równych `Odcinek <numer>`
+- wykrywanie finałów oznaczonych jako `Odcinek <numer> - Finał`
 
 ## Co jest skończone
 - Milestone 0.5
@@ -18,12 +19,15 @@
 - Milestone 1.1
 - Milestone 1.2
 - Milestone 1.3
+- Milestone 1.4
 - PRD dla automatycznego logowania: `prd/001-auto-cookie-login-prd.md`
 - PRD retry autoryzacji: `prd/002-auth-retry-for-first-series-prd.md`
 - PRD ścisłego parsowania etykiet odcinków: `prd/003-strict-episode-label-parsing-prd.md`
+- PRD obsługi finałowych etykiet odcinków: `prd/004-final-episode-label-parsing-prd.md`
 - testy jednostkowe dla logiki sesji, retry logowania i scenariuszy wyczerpania retry
 - smoke test głównego przepływu `process_user()` bez realnego IO
 - testy jednostkowe i smoke test dla etykiet odcinków z dodatkowymi opisami
+- testy jednostkowe i smoke test dla etykiet finałowych na przykładzie `Climax`
 
 ## Co jest w trakcie
 - brak aktywnego wdrożenia; bieżąca praca została domknięta na poziomie kodu i dokumentacji
@@ -51,3 +55,5 @@
 - potwierdzono poprawny realny przebieg `uv run python main.py` z odzyskaniem sesji i wysyłką e-mail
 - wdrożono ścisłe parsowanie etykiet odcinków i ignorowanie dopisków typu `Premiera w Korei: ...`
 - dodano testy `unittest` i smoke test dla przypadku `Climax`, który wcześniej fałszywie wykrywał nowy odcinek
+- dodano PRD `004-final-episode-label-parsing-prd.md`
+- wdrożono obsługę etykiety `Odcinek 10 - Finał`, która wcześniej zatrzymywała `Climax` na odcinku 9

--- a/main.py
+++ b/main.py
@@ -22,7 +22,10 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-EPISODE_LABEL_RE = re.compile(r"^Odcinek\s+(\d+)$", re.IGNORECASE)
+EPISODE_LABEL_RE = re.compile(
+    r"^Odcinek\s+(\d+)(?:\s*[-–]\s*Finał)?$",
+    re.IGNORECASE,
+)
 
 DEFAULT_USER_AGENT = (
     "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "

--- a/prd/004-final-episode-label-parsing-prd.md
+++ b/prd/004-final-episode-label-parsing-prd.md
@@ -1,0 +1,106 @@
+# PRD: Obsługa etykiet finałowych odcinków
+
+## Kontekst
+Parser odcinków został wcześniej zawężony tak, aby akceptować tylko etykiety dokładnie równe `Odcinek <numer>`. To wyeliminowało fałszywe wykrycia zapowiedzi i opisów informacyjnych, ale ujawniło zbyt restrykcyjne zachowanie dla finałów.
+
+Potwierdzony przypadek produkcyjny:
+- arkusz Google Sheets: serial `Climax` ma `odcinek_na_stronie=9` oraz `liczba_odcinków=10`
+- strona: `https://www.dramaqueen.pl/drama/koreanska/climax/`
+- aktualny label finału: `Odcinek 10 - Finał`
+- obecny parser zwraca `latest_ready=9`, `max_found=9`, mimo że finał jest odblokowany i widoczny na stronie
+
+## Problem
+Finałowe odcinki bywają oznaczane dodatkowym dopiskiem `- Finał`, mimo że są realnie dostępne do oglądania.
+
+W efekcie:
+- arkusz może pozostać na przedostatnim dostępnym odcinku
+- użytkownik nie dostaje powiadomienia o finale
+- ręczne sprawdzenie strony jest nadal potrzebne dla części zakończonych seriali
+
+## Cel
+Rozszerzyć regułę parsowania o bezpieczny wyjątek dla polskich etykiet finałowych.
+
+Cel użytkowy:
+- finał serialu ma być wykrywany tak samo jak zwykły dostępny odcinek
+
+Cel techniczny:
+- parser ma akceptować `Odcinek <numer> - Finał`, ale nadal odrzucać zwykłe dopiski informacyjne, takie jak `Premiera w Korei: ...`
+
+## Proponowane rozwiązanie
+Wersja v1 fixu:
+1. Zachować obecne wyszukiwanie kandydatów w elementach `p.toggler`.
+2. Znormalizować tekst elementu tak jak obecnie, przez `get_text(" ", strip=True)`.
+3. Uznawać element za odcinek, gdy cały tekst pasuje do jednego z formatów:
+   - `Odcinek <numer>`
+   - `Odcinek <numer> - Finał`
+4. Dopuścić elastyczne spacje wokół myślnika oraz różną wielkość liter w słowie `Finał`.
+5. Nie dopuszczać dowolnych sufiksów po myślniku ani angielskich wariantów `Final`/`Finale`.
+6. Obecna reguła z obrazkiem blokady pozostaje bez zmiany:
+   - element bez obrazka może podnosić `latest_ready`
+   - element z obrazkiem może podnosić tylko `max_found`
+
+Przykłady:
+- poprawne: `Odcinek 10`
+- poprawne: `Odcinek 10 - Finał`
+- poprawne: `Odcinek 10-Finał`
+- poprawne: `Odcinek 10 - finał`
+- niepoprawne: `Odcinek 6 Premiera w Korei: 31.03.2026`
+- niepoprawne: `Odcinek 6 - wkrótce`
+- niepoprawne: `Odcinek 10 - Final`
+
+## Zakres v1
+Do zakresu tej iteracji wchodzi:
+- rozszerzenie reguły wykrywania odcinków o polskie etykiety finałowe
+- utrzymanie ochrony przed fałszywymi wykryciami dopisków informacyjnych
+- utrzymanie obecnej logiki rozróżnienia między odcinkiem gotowym a zablokowanym przez obecność obrazka
+- dodanie testów `unittest` dla etykiet finałowych i regresji `Climax`
+
+## Poza zakresem v1
+Poza zakresem pozostają:
+- refaktoryzacja `main.py`
+- zmiana selektorów HTML lub źródła danych
+- obsługa dowolnych opisów po numerze odcinka
+- obsługa angielskich albo innych językowych wariantów słowa `Finał`
+- zmiany w logowaniu, Google Sheets, SMTP i konfiguracji środowiskowej
+
+## Wymagania funkcjonalne
+1. Element `Odcinek <numer> - Finał` ma być liczony jako odcinek.
+2. Warianty spacji wokół myślnika i wielkości liter słowa `Finał` mają być akceptowane.
+3. Element zawierający zwykły opis informacyjny nie może wpływać ani na `latest_ready`, ani na `max_found`.
+4. Dla poprawnych prostych etykiet `Odcinek <numer>` obecne zachowanie ma pozostać bez zmiany.
+5. Obecna detekcja zablokowanego odcinka przez obecność obrazka ma pozostać bez zmiany.
+
+## Wymagania niefunkcjonalne
+- brak nowych zależności
+- brak zmian w konfiguracji środowiskowej
+- testy bez realnego IO
+- zgodność z obecnym uruchamianiem przez `uv`
+
+## Wpływ na istniejący system
+- zmiana dotyczy wyłącznie logiki parsowania HTML dla odcinków
+- logowanie, Google Sheets, e-mail i mechanizm sesji pozostają bez zmian
+- wynik parsowania pozostaje restrykcyjny, ale zawiera jawny wyjątek dla realnie dostępnych finałów
+
+## Kryteria sukcesu
+Funkcjonalność będzie uznana za skuteczną, gdy:
+- `Odcinek 10 - Finał` będzie podnosił `latest_ready` do `10`, jeśli element nie ma obrazka blokady
+- przypadek `Climax` przestanie zatrzymywać dostępny odcinek na wartości `9`
+- dopiski typu `Premiera w Korei: ...` nadal będą ignorowane
+- pełny zestaw testów `unittest` będzie przechodził lokalnie
+
+## Kryteria akceptacji
+1. Scenariusz: `Odcinek 10 - Finał` daje numer odcinka `10`.
+2. Scenariusz: `Odcinek 10-Finał`, `Odcinek 10 - finał` i `Odcinek 10 - FINAŁ` są akceptowane.
+3. Scenariusz: `Odcinek 6 Premiera w Korei: 31.03.2026` nadal jest ignorowany.
+4. Scenariusz: HTML z `Odcinek 9` i odblokowanym `Odcinek 10 - Finał` daje `latest_ready=10`.
+5. Scenariusz: HTML z `Odcinek 10 - Finał` z obrazkiem blokady nie podnosi `latest_ready`.
+
+## Ryzyka i ograniczenia
+- jeśli serwis zacznie oznaczać realnie dostępne odcinki innymi dopiskami niż `Finał`, parser nadal ich nie wykryje
+- parser pozostaje zależny od struktury HTML serwisu
+- rozwiązanie świadomie nie cofa ochrony wprowadzonej przez PRD `003-strict-episode-label-parsing-prd.md`
+
+## Założenia
+- obowiązującym formatem zwykłego odcinka pozostaje `Odcinek <numer>`
+- jedynym dopuszczonym sufiksem w tej iteracji jest polskie `Finał`
+- głównym kryterium biznesowym jest poprawne ustawienie dostępnego odcinka dla finału

--- a/spec.md
+++ b/spec.md
@@ -34,6 +34,11 @@ Wdrożone rozszerzenie zakresu (PRD `003-strict-episode-label-parsing-prd.md`):
 - odrzucanie etykiet z dodatkowymi opisami, takimi jak `Premiera w Korei: ...`
 - ograniczenie fałszywych wykryć odcinków jeszcze niedostępnych do oglądania
 
+Wdrożone rozszerzenie zakresu (PRD `004-final-episode-label-parsing-prd.md`):
+- akceptowanie polskich etykiet finałowych `Odcinek <numer> - Finał`
+- utrzymanie odrzucania zwykłych dopisków informacyjnych
+- poprawne wykrywanie odblokowanych finałów jako dostępnych odcinków
+
 Poza zakresem:
 - interfejs WWW, CLI z parserem argumentów lub panel administracyjny
 - trwała baza danych poza Google Sheets
@@ -79,6 +84,11 @@ Wdrożone rozszerzenie wynikające z PRD `002-auth-retry-for-first-series-prd.md
 Wdrożone rozszerzenie wynikające z PRD `003-strict-episode-label-parsing-prd.md`:
 - parser ma uznawać za istniejący odcinek tylko taki element HTML, którego pełny tekst po normalizacji jest dokładnie równy `Odcinek <numer>`
 - elementy zawierające dodatkowy opis, nawet jeśli zawierają numer odcinka, nie mają wpływać na `latest_ready` ani `max_found`
+
+Wdrożone rozszerzenie wynikające z PRD `004-final-episode-label-parsing-prd.md`:
+- parser ma dodatkowo uznawać za istniejący odcinek polską etykietę finałową `Odcinek <numer> - Finał`
+- warianty spacji wokół myślnika i wielkości liter słowa `Finał` są akceptowane
+- inne dopiski po numerze odcinka nadal nie mają wpływać na `latest_ready` ani `max_found`
 
 ---
 
@@ -134,7 +144,7 @@ Obecne ograniczenie architektoniczne:
 - moduł translacji sesji przeglądarki: przeniesienie pełnego zestawu cookie do klienta `requests`
 - mechanizm walidacji sesji: wykrycie utraty autoryzacji i wywołanie ponownego logowania
 - mechanizm retry autoryzacji: ponowna próba odzyskania sesji i ponowienie sprawdzenia tego samego serialu po chwilowej awarii logowania/cookie
-- parser odcinków: pełne dopasowanie całego labela zamiast częściowego wykrywania numeru
+- parser odcinków: pełne dopasowanie całego labela z jawną obsługą polskiej etykiety finałowej
 
 Zewnętrzne zależności wykonawcze:
 - Google Sheets API przez konto serwisowe
@@ -236,6 +246,13 @@ Zewnętrzne zależności wykonawcze:
     Konsekwencje:
     Parser stanie się bardziej restrykcyjny i może pominąć odcinki, jeśli serwis zacznie dopisywać dodatkowy tekst także przy realnie dostępnych odcinkach, ale ograniczy błędne aktualizacje arkusza i fałszywe powiadomienia.
 
+14. Decyzja (dotyczy PRD: `004-final-episode-label-parsing-prd.md`):
+    Parser odcinków ma dopuścić polski sufiks finałowy `- Finał` jako bezpieczny wyjątek od ścisłej reguły `Odcinek <numer>`.
+    Uzasadnienie:
+    Serwis oznacza realnie dostępne finały formatem takim jak `Odcinek 10 - Finał`, co przy poprzedniej regule blokowało wykrycie ostatniego odcinka serialu `Climax`.
+    Konsekwencje:
+    Parser poprawnie wykrywa finały bez rozluźniania reguły na dowolne dopiski informacyjne, ale nadal może pominąć inne nieznane warianty etykiet.
+
 ---
 
 ## Jakość i kryteria akceptacji
@@ -270,6 +287,12 @@ Minimalne kryteria akceptacji dla rozszerzenia z PRD `002-auth-retry-for-first-s
 - po wyczerpaniu limitu retry aplikacja raportuje błąd końcowy w sposób czytelny
 - testy `unittest` obejmują scenariusz: pierwsza próba nieudana, druga udana
 
+Minimalne kryteria akceptacji dla rozszerzenia z PRD `004-final-episode-label-parsing-prd.md`:
+- etykieta `Odcinek <numer> - Finał` jest liczona jako odcinek
+- odblokowany finał podnosi `latest_ready`
+- zablokowany finał może podnosić tylko `max_found`
+- dopiski informacyjne typu `Premiera w Korei: ...` nadal są ignorowane
+
 ---
 
 ## Zasady zmian i ewolucji
@@ -289,10 +312,11 @@ Minimalne kryteria akceptacji dla rozszerzenia z PRD `002-auth-retry-for-first-s
 - Ta specyfikacja opisuje stan bieżącej implementacji, a nie docelowy, pełny plan rozwoju.
 - PRD `001-auto-cookie-login-prd.md` został zrealizowany dla Milestone 1.0 i wprowadził automatyczne logowanie oraz odświeżanie sesji przez Playwright.
 - PRD `002-auth-retry-for-first-series-prd.md` został zrealizowany i dodał odporność na chwilowe błędy logowania przez kontrolowane retry oraz ponowienie sprawdzenia serialu.
+- PRD `004-final-episode-label-parsing-prd.md` został zrealizowany i dodał obsługę polskich etykiet finałowych bez cofania ochrony przed dopiskami informacyjnymi.
 
 ---
 
 ## Status specyfikacji
 - Data utworzenia: 2026-03-21
-- Ostatnia aktualizacja: 2026-03-23
-- Aktualny zakres obowiązywania: bieżąca implementacja skryptu `main.py`, konfiguracja z `pyproject.toml`, opis projektu z `README.md`, wdrożone logowanie Playwright z PRD `001-auto-cookie-login-prd.md` oraz wdrożone retry autoryzacji z PRD `002-auth-retry-for-first-series-prd.md`
+- Ostatnia aktualizacja: 2026-05-14
+- Aktualny zakres obowiązywania: bieżąca implementacja skryptu `main.py`, konfiguracja z `pyproject.toml`, opis projektu z `README.md`, wdrożone logowanie Playwright z PRD `001-auto-cookie-login-prd.md`, wdrożone retry autoryzacji z PRD `002-auth-retry-for-first-series-prd.md`, ścisłe parsowanie etykiet z PRD `003-strict-episode-label-parsing-prd.md` oraz obsługa finałów z PRD `004-final-episode-label-parsing-prd.md`

--- a/tests/test_auth_session.py
+++ b/tests/test_auth_session.py
@@ -46,13 +46,18 @@ class FlakyAuthenticator:
 
 
 class AuthSessionTests(unittest.TestCase):
-    def test_extract_episode_number_accepts_only_exact_episode_label(self):
+    def test_extract_episode_number_accepts_exact_episode_and_final_label(self):
         self.assertEqual(6, main.extract_episode_number("Odcinek 6"))
         self.assertEqual(6, main.extract_episode_number("  Odcinek 6  "))
+        self.assertEqual(10, main.extract_episode_number("Odcinek 10 - Finał"))
+        self.assertEqual(10, main.extract_episode_number("Odcinek 10-Finał"))
+        self.assertEqual(10, main.extract_episode_number("Odcinek 10 - finał"))
+        self.assertEqual(10, main.extract_episode_number("Odcinek 10 - FINAŁ"))
         self.assertIsNone(
             main.extract_episode_number("Odcinek 6 Premiera w Korei: 31.03.2026")
         )
         self.assertIsNone(main.extract_episode_number("Odcinek 6 - wkrótce"))
+        self.assertIsNone(main.extract_episode_number("Odcinek 10 - Final"))
 
     def test_find_episodes_ignores_labels_with_additional_description(self):
         html = """
@@ -78,6 +83,30 @@ class AuthSessionTests(unittest.TestCase):
         self.assertEqual("Nie znaleziono nagłówków odcinków.", result.error)
         self.assertIsNone(result.latest_ready)
         self.assertIsNone(result.max_found)
+
+    def test_find_episodes_accepts_unlocked_final_episode_label(self):
+        html = """
+        <p class="toggler">Odcinek 9</p>
+        <p class="toggler">Odcinek 10 - Finał</p>
+        """
+
+        result = main.find_episodes(html)
+
+        self.assertIsNone(result.error)
+        self.assertEqual(10, result.latest_ready)
+        self.assertEqual(10, result.max_found)
+
+    def test_find_episodes_counts_locked_final_only_as_max_found(self):
+        html = """
+        <p class="toggler">Odcinek 9</p>
+        <p class="toggler"><img src="locked.png">Odcinek 10 - Finał</p>
+        """
+
+        result = main.find_episodes(html)
+
+        self.assertIsNone(result.error)
+        self.assertEqual(9, result.latest_ready)
+        self.assertEqual(10, result.max_found)
 
     def test_extract_auth_cookies_filters_only_session_cookies(self):
         cookies = [

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -193,6 +193,70 @@ class SmokeFlowTests(unittest.TestCase):
             main.open_sheet = original_open_sheet
             main.send_email = original_send_email
 
+    def test_process_user_accepts_climax_final_episode_label(self):
+        login_page = FakeResponse(
+            url="https://www.dramaqueen.pl/wp-login.php?redirect_to=%2Fserial",
+            text='<input id="user_login" name="log"><input id="user_pass" name="pwd"><input id="wp-submit">',
+        )
+        episode_page = FakeResponse(
+            url="https://www.dramaqueen.pl/drama/koreanska/climax/",
+            text="""
+            <p class="toggler">Odcinek 9</p>
+            <p class="toggler">Odcinek 10 - Finał</p>
+            """,
+        )
+        session = FakeSession([login_page, episode_page])
+        authenticator = FakeAuthenticator()
+        worksheet = FakeWorksheet()
+        worksheet.values[1][0] = "Climax"
+        worksheet.values[1][1] = "https://www.dramaqueen.pl/drama/koreanska/climax/"
+        worksheet.values[1][2] = "1"
+        worksheet.values[1][3] = "9"
+        worksheet.values[1][4] = "10"
+        sent_messages = []
+
+        original_authenticate_gspread = main.authenticate_gspread
+        original_open_sheet = main.open_sheet
+        original_send_email = main.send_email
+        try:
+            main.authenticate_gspread = lambda service_account_file: object()
+            main.open_sheet = lambda gc, spreadsheet_title, worksheet_title: (
+                object(),
+                worksheet,
+            )
+
+            def fake_send_email(subject, html_body, email_to):
+                sent_messages.append(
+                    {
+                        "subject": subject,
+                        "html_body": html_body,
+                        "email_to": email_to,
+                    }
+                )
+
+            main.send_email = fake_send_email
+
+            cfg = main.UserConfig(
+                sheet_title="dramy",
+                worksheet_title="Arkusz1",
+                email_to="example@example.com",
+                always_send=False,
+                service_account_file="service_account.json",
+            )
+
+            result = main.process_user(cfg, session, authenticator)
+
+            self.assertEqual(0, result)
+            self.assertEqual(1, authenticator.calls)
+            self.assertEqual([(2, 4, 10)], worksheet.updated_cells)
+            self.assertEqual(1, len(sent_messages))
+            self.assertIn("Climax", sent_messages[0]["html_body"])
+            self.assertIn("<strong>10</strong>", sent_messages[0]["html_body"])
+        finally:
+            main.authenticate_gspread = original_authenticate_gspread
+            main.open_sheet = original_open_sheet
+            main.send_email = original_send_email
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add PRD 004 for final episode label parsing
- accept Polish final labels like `Odcinek 10 - Finał` while keeping informational labels rejected
- add unit and smoke coverage for the Climax regression

## Tests
- `uv run python -m unittest discover -s tests -p "test_*.py"`
- real app run completed and updated Climax from 9 to 10